### PR TITLE
feature: 버튼 컴포넌트화, 홈페이지 구현, 탭 전환시 상태 유지 하지 않도록 변경

### DIFF
--- a/lib/components/app_bar.dart
+++ b/lib/components/app_bar.dart
@@ -30,3 +30,64 @@ class DefaultAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 }
+
+class SearchAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const SearchAppBar({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+
+    // SafeArea -> 노치 등 시스템 UI와 겹치지 않게 함
+    return SafeArea(
+
+      // appBar 대신 Container 반환
+      child: Container(
+        height: preferredSize.height,
+        color: Colors.transparent, // AppBar 배경 없음
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        alignment: Alignment.center,
+        child: Container(
+          height: 40,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(30),
+
+          ),
+          child: TextField(
+            decoration: InputDecoration(
+              hintText: '가고싶은 여행지를 검색하세요!',
+              hintStyle: const TextStyle(fontSize: 16, color: Colors.grey),
+
+              // 입력 가능할 경우(아무 동작도 하지 않았을 때) 검색창 스타일
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(30),
+                borderSide: const BorderSide(color: Color(0xFFD9D9D9))
+              ),
+
+              // 입력 중일 경우 검색창 스타일
+              focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(30),
+                  borderSide: const BorderSide(color: Color(0xFFD9D9D9))
+              ),
+
+              // 입력 중인 텍스트에 대한 패딩
+              contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+
+              // 검색창 우측 부분에 표시될 아이콘
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.search, color: Color(0xFF1E1E1E)),
+                onPressed: () {
+                  // 더미 검색 기능
+                  debugPrint("검색 버튼 클릭됨 (추후 기능 연결 예정)");
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(100);
+}

--- a/lib/components/plan_card.dart
+++ b/lib/components/plan_card.dart
@@ -5,12 +5,16 @@ class PlanCard extends StatelessWidget {
   final String title;      // 카드 제목
   final String startDate;  // 여행 시작 날짜 (형식: YYYY.MM.DD)
   final String endDate;    // 여행 종료 날짜 (형식: YYYY.MM.DD)
+  final double size_h; // 카드의 높이
+  final double size_w; // 카드의 너비
 
   const PlanCard({
     Key? key,
     required this.title,
     required this.startDate,
     required this.endDate,
+    required this.size_h,
+    required this.size_w,
   }) : super(key: key);
 
   // 종료일까지 남은 일 수 계산
@@ -28,76 +32,80 @@ class PlanCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final remainingDays = calculateRemainingDays(endDate);
 
-    return InkWell(
-      // 카드 클릭 시 다음 페이지로 이동
-      onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const ConnectionPageExample(),
-          ),
-        );
-      },
+    return SizedBox( // 카드 위젯의 크기 명시
+      height: size_h,
+      width: size_w,
       child: Card(
+        clipBehavior: Clip.antiAlias, // 카드 외부 영역이 터지되지 않도록 처리함
+      
         color: Color(0xFFF5F5F5),
         elevation: 4,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
         ),
-        margin: const EdgeInsets.all(16),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 40, 20, 40),
-
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisSize: MainAxisSize.min,
-
-            children: [
-              // D-day 표시 영역
-              Card(
-                color: Colors.red[600],
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                margin: const EdgeInsets.all(5),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 1),
-                  child: Text(
-                    "D-$remainingDays",
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 8,
-                      fontWeight: FontWeight.bold,
+        child: InkWell(
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => const ConnectionPageExample(),
+              ),
+            );
+          },
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 40, 20, 40),
+      
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+      
+              children: [
+                // D-day 표시 영역
+                Card(
+                  color: Colors.red[600],
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  margin: const EdgeInsets.all(5),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 1),
+                    child: Text(
+                      "D-$remainingDays",
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 8,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
                 ),
-              ),
-
-              const SizedBox(height: 8),
-
-              // 여행 제목
-              Text(
-                title,
-                style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
-              ),
-
-              const SizedBox(height: 8),
-
-              // 여행 날짜 범위 (달력 아이콘 + 텍스트)
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(Icons.calendar_today, size: 13, color: Colors.grey),
-                  const SizedBox(width: 5),
-                  Text(
-                    dateRange,
-                    style: TextStyle(fontSize: 12, color: Colors.grey),
-                  ),
-                ],
-              ),
-            ],
+      
+                const SizedBox(height: 8),
+      
+                // 여행 제목
+                Text(
+                  title,
+                  style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+                ),
+      
+                const SizedBox(height: 8),
+      
+                // 여행 날짜 범위 (달력 아이콘 + 텍스트)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.calendar_today, size: 13, color: Colors.grey),
+                    const SizedBox(width: 5),
+                    Text(
+                      dateRange,
+                      style: TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/components/proceed_button.dart
+++ b/lib/components/proceed_button.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class ProceedButton extends StatelessWidget {
+  final double size_w; // 버튼 너비
+  final double size_h; // 버튼 높이
+  final String text; // 버튼 텍스트
+  final FontWeight fontWeight_; // 버튼 텍스트 굵기
+  final double fontSize_; // 버튼 텍스트 크기
+  final EdgeInsetsGeometry padding_; // 버튼 패딩값
+  final Function()? onTap; // 탭할 시 실행될 함수
+
+  const ProceedButton ({
+    Key? key,
+    required this.size_w,
+    required this.size_h,
+    required this.text,
+    required this.fontSize_,
+    required this.fontWeight_,
+    required this.padding_,
+    this.onTap
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onTap,
+      style: ButtonStyle(
+
+        // WidgetStateProperty.all -> hover, tap 등 모든 동작 상황에 같은 스타일 적용
+        backgroundColor: WidgetStateProperty.all(const Color(0xFF2C2C2C)),
+        foregroundColor: WidgetStateProperty.all(const Color(0xFFF5F5F5)),
+        padding: WidgetStateProperty.all(padding_),
+        fixedSize: WidgetStateProperty.all(Size(size_w, size_h)),
+        shape: WidgetStateProperty.all(
+          RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+        ),
+        textStyle: WidgetStateProperty.all(
+          TextStyle(
+            fontSize: fontSize_,
+            fontWeight: fontWeight_,
+          ),
+        ),
+      ),
+      child: Text(text),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 /*
 * << 파일 변경사항에 따라 지속적으로 수정될 예정 >>
 * - 2025-03-21: 최초 추가
+* - 2025-03-23: proceed_button.dart 추가, app_bar.dart에 SearchBar 클래스 추가, plan_card.dart에 사이즈값 인자 추가
 * < 네이밍 관련 >
 * - 모든 코드 작성은 피그마 페이지를 기준으로 함
 * - 같은 탭(홈,계획,추가,마이) 내의 페이지일 경우 <탭 이름>_<라우팅 순서>로 네이밍 함
@@ -25,6 +26,7 @@
 *   2. bottom_navi_bar.dart : 색상, radius, Items(아이콘, 라벨) 정의
 *   3. dropdown_card.dart : 추가 탭의 첫 번째 페이지에 사용되는 드롭다운 박스 요소
 *   4. plan_card.dart : 홈, 계획 탭에 사용되는 여행 정보를 나타내는 카드 요소
+*   5. proceed_button.dart : 계획, 홈 탭에서 사용되는 버튼(검은색), 주로 다음 단계로 건너가기 위한 버튼으로 사용됨
 * */
 
 import 'package:flutter/material.dart';
@@ -35,13 +37,18 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
+  final String username = '홍길동';
+  final String welcome_message = '오늘도 좋은 하루에요👋';
+
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: const MainScreen(),
+      home: MainScreen(
+        username: username,
+        welcome_message: welcome_message),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,8 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
+
+  // username, welcome_message : homepage에서 사용될 텍스트 정보
   final String username = '홍길동';
   final String welcome_message = '오늘도 좋은 하루에요👋';
 

--- a/lib/mainscreen.dart
+++ b/lib/mainscreen.dart
@@ -6,7 +6,14 @@ import 'pages/plan_page/plan_page.dart';
 import 'components/bottom_navi_bar.dart';
 
 class MainScreen extends StatefulWidget {
-  const MainScreen({Key? key}) : super(key: key);
+  final String username;
+  final String welcome_message;
+
+  const MainScreen({
+    required this.username,
+    required this.welcome_message,
+    Key? key
+  }) : super(key: key);
 
   @override
   _MainScreenState createState() => _MainScreenState();
@@ -14,13 +21,14 @@ class MainScreen extends StatefulWidget {
 
 class _MainScreenState extends State<MainScreen> {
   int _currentIndex = 0;
-
   // 각 탭 별 Navigator 상태를 추적하기 위한 키 리스트
   late List<GlobalKey<NavigatorState>> _navigatorKeys;
 
   // 하단 탭에 연결될 페이지 목록
-  final List<Widget> _pages = [
-    const HomePage(),
+  List<Widget> get _pages => [
+    HomePage(
+        username: widget.username,
+        welcome_message: widget.welcome_message),
     const PlanPage(),
     const AddPage(),
     const MyPage(),
@@ -39,14 +47,14 @@ class _MainScreenState extends State<MainScreen> {
 
   // 안드로이드 '뒤로 가기' 동작 처리
   Future<bool> _onPop() async {
-    final canPop = await _navigatorKeys[_currentIndex].currentState?.maybePop() ?? false;
+    final canPop = await _navigatorKeys[_currentIndex].currentState
+        ?.maybePop() ?? false;
     return !canPop;
   }
 
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      // 시스템 뒤로가기 버튼 제어: 앱이 곧바로 종료되지 않도록 처리
       canPop: false,
       onPopInvokedWithResult: (didPop, result) async {
         if (!didPop) {
@@ -54,29 +62,24 @@ class _MainScreenState extends State<MainScreen> {
         }
         true;
       },
-
       child: Scaffold(
         extendBody: true,
 
-        // IndexedStack으로 탭별 상태 유지 및 중첩 네비게이션 처리
-        body: IndexedStack(
-          index: _currentIndex,
-          children: List.generate(_pages.length, (index) {
-            return Navigator(
-              key: _navigatorKeys[index],
-              onGenerateRoute: (settings) => MaterialPageRoute(
-                builder: (context) => _pages[index],
+        //  IndexedStack 제거 → 상태 유지 안함
+        //  선택된 탭 페이지만 직접 렌더링
+        body: Navigator(
+          key: _navigatorKeys[_currentIndex],
+          onGenerateRoute: (settings) =>
+              MaterialPageRoute(
+                builder: (context) => _pages[_currentIndex],
               ),
-            );
-          }),
         ),
 
-        // 하단 커스텀 네비게이션 바
         bottomNavigationBar: CustomBottomNavigationBar(
           currentIndex: _currentIndex,
           onTap: (index) {
             setState(() {
-              _currentIndex = index; // 탭 전환 시 상태 갱신
+              _currentIndex = index;
             });
           },
         ),

--- a/lib/pages/add_page/add_page_2.dart
+++ b/lib/pages/add_page/add_page_2.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'add_page_3.dart';
 import '../../components/app_bar.dart';
+import '../../components/proceed_button.dart';
 
 class AddPage_2 extends StatelessWidget {
   final String title;
@@ -20,24 +21,28 @@ class AddPage_2 extends StatelessWidget {
 
       body: Stack(
         // "이 코스로 할게요!" 버튼이 다른 UI 요소 위에 그려지도록 하기 위해 Stack 사용
+        alignment: Alignment.center,
         children: [
           SingleChildScrollView(
-            child: ConstrainedBox(
-              // Stack + ScrollView 조합 시, 자식 요소가 화면을 벗어나 배치되는 문제 방지를 위해 사용
-              constraints: BoxConstraints(
-                  minHeight: MediaQuery.of(context).size.height, // 최소 높이를 화면 크기로 제한
-                  minWidth: MediaQuery.of(context).size.width
-              ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 26),
+              child: ConstrainedBox(
+                // Stack + ScrollView 조합 시, 자식 요소가 화면을 벗어나 배치되는 문제 방지를 위해 사용
+                constraints: BoxConstraints(
+                    minHeight: MediaQuery.of(context).size.height, // 최소 높이를 화면 크기로 제한
+                    minWidth: MediaQuery.of(context).size.width
+                ),
 
-              // 코스 정보를 담은 UI 블록들을 수직으로 배치
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    "$title, $place",
-                    style: TextStyle(fontSize: 20),
-                  ),
-                ],
+                // 코스 정보를 담은 UI 블록들을 수직으로 배치
+                child: Column(
+                  //crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      "$title, $place",
+                      style: TextStyle(fontSize: 20),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -45,8 +50,14 @@ class AddPage_2 extends StatelessWidget {
           // "이 코스로 할게요!" 버튼을 화면 하단에 고정 배치
           Positioned(
             bottom: 90,
-            child: ElevatedButton(
-              onPressed: () {
+            child: ProceedButton(
+              size_w: 250,
+              size_h: 45,
+              text: "이 코스로 할게요!",
+              fontSize_: 13,
+              fontWeight_: FontWeight.bold,
+              padding_: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 12.0),
+              onTap: () {
                 Navigator.push(
                   context,
                   CupertinoPageRoute(
@@ -54,27 +65,6 @@ class AddPage_2 extends StatelessWidget {
                   ),
                 );
               },
-
-              // 버튼 스타일 지정 (크기, 색상, 모서리 둥글기 등)
-              style: ElevatedButton.styleFrom(
-                fixedSize: Size(250, 45),
-                padding: EdgeInsets.symmetric(vertical: 12.0, horizontal: 12.0),
-                backgroundColor: Color(0xFF2C2C2C),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
-              ),
-
-              child: Center(
-                child: Text(
-                  "이 코스로 할게요!",
-                  style: TextStyle(
-                    color: Color(0xFFF5F5F5),
-                    fontSize: 13,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
             ),
           )
         ],

--- a/lib/pages/home_page/home_page.dart
+++ b/lib/pages/home_page/home_page.dart
@@ -1,9 +1,17 @@
 import 'package:flutter/material.dart';
 import '../../components/app_bar.dart';
 import '../../components/plan_card.dart'; // 여행 계획 카드 컴포넌트
+import '../../components/proceed_button.dart'; // 버튼 컴포넌트
 
 class HomePage extends StatelessWidget {
-  const HomePage({Key? key}) : super(key: key);
+  final String username;
+  final String welcome_message;
+
+  const HomePage({
+    required this.username,
+    required this.welcome_message,
+    Key? key
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -11,19 +19,85 @@ class HomePage extends StatelessWidget {
       backgroundColor: Color(0xFFFFFFFF),
 
       // 상단 앱바
-      appBar: const DefaultAppBar(title: "홈 앱바 영역"),
+      appBar: const SearchAppBar(),
 
       // 콘텐츠 영역
       body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16), // 좌우 여백 설정
+        padding: const EdgeInsets.symmetric(horizontal: 25), // 좌우 여백 설정
 
         // 여행 계획 카드요소 및 텍스트 세로 방향으로 나열
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            PlanCard(
-              title: "성북구 산책",
-              startDate: "2025.03.18",
-              endDate: "2025.03.25",
+
+            // 유저 이름
+            Text(
+              '$username님,',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20)
+            ),
+
+            // 웰컴 메세지
+            Text(
+                '$welcome_message',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20)
+            ),
+            SizedBox(height: 20,),
+            Text(
+              '⏰다가오는 일정',
+              style: TextStyle(fontSize: 27, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 10,),
+            Center(
+              child: PlanCard(
+                title: "성북구 산책",
+                startDate: "2025.03.18",
+                endDate: "2025.03.25",
+                size_h: 320,
+                size_w: 300,
+              ),
+            ),
+            SizedBox(height: 60,),
+            Center(
+              /*
+              * size_w, size_h, fontSize_ : double
+              * text : String
+              * fontWeight_ : FontWeight
+              * padding_ : EdgeInsetsGeometry
+              * */
+              child: ProceedButton(
+                  size_w: 220,
+                  size_h: 45,
+                  text: "✨새로운 장소 탐험하기",
+                  fontSize_: 15,
+                  fontWeight_: FontWeight.bold,
+                  padding_: EdgeInsets.symmetric(vertical: 12.0, horizontal: 12.0)
+              )
+
+              /*ElevatedButton(
+                onPressed: () {
+                },
+
+                // 버튼 스타일 지정 (크기, 색상, 모서리 둥글기 등)
+                style: ElevatedButton.styleFrom(
+                  fixedSize: Size(220, 45),
+                  padding: EdgeInsets.symmetric(vertical: 12.0, horizontal: 12.0),
+                  backgroundColor: Color(0xFF2C2C2C),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+
+                child: Center(
+                  child: Text(
+                    "✨새로운 장소 탐험하기",
+                    style: TextStyle(
+                      color: Color(0xFFF5F5F5),
+                      fontSize: 15,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),*/
             ),
           ],
         ),


### PR DESCRIPTION
## 📌 관련 이슈
#11 

## ✨ 작업내용
- 버튼 컴포넌트화 : 계획, 홈 탭에서 사용되는 버튼(검은색) proceed_button.dart 로 분리구현
- homepage 구현 : 아직 미완성, 이후 ScrollView 추가 예정
- 탭 상태유지 롤백 : IndexedStack 위젯으로 상태가 유지되도록 했었던 부분 다시 롤백함 

### 스크린샷 (선택)

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말