### PR TITLE
[FEAT] 미션 페이지 API 연동 및 상세페이지 구현 #24

### DIFF
--- a/lib/components/plan_card.dart
+++ b/lib/components/plan_card.dart
@@ -1,6 +1,5 @@
 import 'package:alpha_fe/pages/plan_page/plan_page_2.dart';
 import 'package:flutter/material.dart';
-import '../pages/connection_example.dart'; // 연결될 페이지 import
 
 class PlanCard extends StatelessWidget {
   final String title;      // 카드 제목

--- a/lib/pages/my_page/mission_page.dart
+++ b/lib/pages/my_page/mission_page.dart
@@ -1,85 +1,162 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import '../../components/app_bar.dart';
+import 'package:alpha_fe/pages/my_page/mission_page_2.dart';
 
-class Mission_Page extends StatelessWidget {
+class Mission_Page extends StatefulWidget {
   const Mission_Page({Key? key}) : super(key: key);
 
   @override
+  State<Mission_Page> createState() => _Mission_PageState();
+}
+
+class _Mission_PageState extends State<Mission_Page> {
+  List<Map<String, dynamic>> _missions = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchMissions();
+  }
+
+  Future<void> _fetchMissions() async {
+    final response = await http.get(Uri.parse('http://localhost:8000/mission/list/'));
+    if (response.statusCode == 200) {
+      final List data = jsonDecode(response.body);
+      setState(() {
+        _missions = data.cast<Map<String, dynamic>>();
+        _isLoading = false;
+      });
+    } else {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    int completed = _missions.where((m) => m['isCompleted'] == true).length;
+    int total = _missions.length;
+
     return Scaffold(
-      backgroundColor: Color(0xFFFFFFFF),
+      backgroundColor: const Color(0xFFFFFFFF),
       appBar: const DefaultAppBar(title: "미션페이지"),
-      body: SingleChildScrollView(
-        padding: EdgeInsets.all(16.0),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : SingleChildScrollView(
+        padding: EdgeInsets.all(width * 0.05),
         child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              SizedBox(height: 44),
-              Center(                //미션 진행도 원형 상태바
-                child: SizedBox(
-                  height: 150, width: 150,
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      CircularProgressIndicator(
-                        value: 9 / 10,  //나중에 이부분 미션 개수랑 성공 여부에 따라 값 달라질 부분
-                        strokeWidth: 20,
-                        backgroundColor: Colors.grey.shade300,
-                        valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF000000)),
-                      ),
-                      Center(
-                        child: Text(
-                          '9/10', // 나중에 미션 개수랑 성공 여부에 따락 값 달라질 부분
-                          style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            SizedBox(height: width * 0.1),
+
+            // ✅ 반응형 원형 진행률 표시
+            LayoutBuilder(
+              builder: (context, constraints) {
+                double size = constraints.maxWidth * 0.5;
+                return Center(
+                  child: SizedBox(
+                    height: size,
+                    width: size,
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        CircularProgressIndicator(
+                          value: total == 0 ? 0 : completed / total,
+                          strokeWidth: width * 0.05,
+                          backgroundColor: Colors.grey.shade300,
+                          valueColor: const AlwaysStoppedAnimation<Color>(Color(0xFF000000)),
                         ),
-                      )
-                    ],
+                        Center(
+                          child: Text(
+                            '$completed/$total',
+                            style: TextStyle(
+                              fontSize: size * 0.15,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        )
+                      ],
+                    ),
                   ),
-                ),
-              ),
-              SizedBox(height: 40),
-              Column(            //미션 및 설명들
-                children: [ //이것도 미션 리스트 어케 받아오냐에 따라 달라짐
-                  _missionItem(false, "미션 ",["내용1","내용2"]),
-                  _missionItem(false, "미션1 ",["내용1","내용2"]),
-                  _missionItem(true, "미션2 ",["내용1","내용2"]),
-                  _missionItem(true, "미션3",["내용1","내용2",""]),
-                ],
-              ),
-            ]
+                );
+              },
+            ),
+
+            SizedBox(height: width * 0.1),
+
+            // ✅ 미션 카드 리스트
+            Column(
+              children: _missions.map((mission) {
+                return _missionItem(context, mission, width);
+              }).toList(),
+            ),
+          ],
         ),
       ),
     );
   }
 }
 
-Widget _missionItem(bool isCompleted, String mission, List<String> tasks) {  //미션이랑 미션 내용 나타내는거 위젯으로 그냥 해 놓음
-  return Card(
-    child: Padding(padding: EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                isCompleted ? Icons.check_circle : Icons.cancel,
-                color: isCompleted ? Color(0xFF008000) : Color(0xFFFF0000),
+Widget _missionItem(BuildContext context, Map<String, dynamic> mission, double width) {
+  final bool isCompleted = mission['isCompleted'] ?? false;
+
+  return Padding(
+    padding: EdgeInsets.symmetric(vertical: width * 0.02),
+    child: ConstrainedBox(
+      constraints: BoxConstraints(
+        maxWidth: width * 0.95,
+      ),
+      child: GestureDetector(
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => MissionPage_2(
+                content: mission['content'], //미션 내용 보내는거 상세페이지로
+                isCompleted: isCompleted, //미션 성공여부 여긴 나중에 api 수정된면 바꿔야함
               ),
-              SizedBox(width: 7,),
-              Text(mission,
-                style: TextStyle(fontSize: 25,fontWeight: FontWeight.bold),
-              ),
-            ],
+            ),
+          );
+        },
+        child: Card(
+          child: Padding(
+            padding: EdgeInsets.all(width * 0.04),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(
+                      isCompleted ? Icons.check_circle : Icons.cancel,
+                      color: isCompleted ? const Color(0xFF008000) : const Color(0xFFFF0000),
+                      size: width * 0.06,
+                    ),
+                    SizedBox(width: width * 0.02),
+                    Text(
+                      "미션 ${mission['id']}", //미션 id
+                      style: TextStyle(
+                        fontSize: width * 0.05,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+                Padding(
+                  padding: EdgeInsets.only(left: width * 0.08, top: width * 0.01),
+                  child: Text(
+                    "• ${mission['content']}", //미션  내용
+                    style: TextStyle(fontSize: width * 0.04),
+                  ),
+                ),
+              ],
+            ),
           ),
-          Column(
-            children: tasks
-                .map((task) => Padding(
-              padding: const EdgeInsets.only(left: 24.0, top: 4),
-              child: Text("• $task", style: TextStyle(fontSize: 15)),
-            ))
-                .toList(),
-          )
-        ],
+        ),
       ),
     ),
   );

--- a/lib/pages/my_page/mission_page_2.dart
+++ b/lib/pages/my_page/mission_page_2.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import '../../components/app_bar.dart';
+
+class MissionPage_2 extends StatelessWidget {
+  final String content;
+  final bool isCompleted;
+
+  const MissionPage_2({
+    Key? key,
+    required this.content,
+    required this.isCompleted,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const DefaultAppBar(title: "미션 앱바 영역"),
+      body: MissionPage_2_body(content: content, isCompleted: isCompleted),
+    );
+  }
+}
+
+class MissionPage_2_body extends StatefulWidget {
+  final String content;
+  final bool isCompleted;
+
+  const MissionPage_2_body({
+    super.key,
+    required this.content,
+    required this.isCompleted,
+  });
+
+  @override
+  State<MissionPage_2_body> createState() => _MissionPage_2_bodyState();
+}
+
+class _MissionPage_2_bodyState extends State<MissionPage_2_body> {
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(width * 0.05),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            // ✅ 상태 표시
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  widget.isCompleted ? Icons.check_circle : Icons.cancel,
+                  color: widget.isCompleted ? const Color(0xFF008000) : const Color(0xFFFF0000),
+                  size: width * 0.06,
+                ),
+                SizedBox(width: width * 0.02),
+                Text(
+                  widget.isCompleted ? "성공한 미션" : "미완료",
+                  style: TextStyle(fontSize: width * 0.045),
+                ),
+              ],
+            ),
+
+            SizedBox(height: width * 0.05),
+
+            // ✅ 미션 설명
+            Text(
+              widget.content,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: width * 0.043,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+
+            SizedBox(height: width * 0.1),
+
+            // ✅ 촬영 버튼
+            if (!widget.isCompleted) //미완료 미션일 경우만 사진 촬영버튼 나타나도록
+              ElevatedButton.icon(
+                onPressed: () {
+                  // TODO: 카메라 촬영 기능 연결 예정
+                },
+                icon: Icon(Icons.camera_alt, size: width * 0.06),
+                label: Text(
+                  "사진 촬영",
+                  style: TextStyle(fontSize: width * 0.045),
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.white,
+                  foregroundColor: Colors.black,
+                  side: BorderSide(color: Colors.black, width: 0.3),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(width * 0.025),
+                  ),
+                  padding: EdgeInsets.symmetric(
+                    horizontal: width * 0.08,
+                    vertical: width * 0.035,
+                  ),
+                  elevation: 2,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#24 

## ✨ 작업내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
미션 페이지에 미션 가져오기 api 연동하고  각각 미션별로 연결될 상세페이지 구현 

### 스크린샷 (선택)
<!--스크린샷을 남겨서 PR에 도움을 줄 수 있다면 스크린샷을 넣어주시는 것을 권장드립니다.-->

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
plan_card는 안쓰는 import 지운거임