### PR TITLE
[FEAT] 계획 페이지 최종 api 연결

### DIFF
--- a/lib/components/trip_generator_card.dart
+++ b/lib/components/trip_generator_card.dart
@@ -1,12 +1,16 @@
+// 추가 페이지에서 사용되는 행정구역 선택 버튼 아이템입니다
+// 해당 버튼은 항상 AddPage_2 로 연결됩니다
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import '../pages/add_page/add_page_2.dart';
 
 class GeneratorItem extends StatelessWidget {
   final String title;
+  final int tourId;
 
   const GeneratorItem({
     required this.title,
+    required this.tourId,
     Key? key,
   }) : super(key: key);
 
@@ -24,7 +28,7 @@ class GeneratorItem extends StatelessWidget {
           Navigator.push(
             context,
             CupertinoPageRoute(
-              builder: (context) => AddPage_2(title: title),
+              builder: (context) => AddPage_2(title: title, tourId: tourId,),
             ),
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,7 +38,6 @@ final logger = Logger();
 
 // 네이버맵 sdk 초기화 함수
 Future<void> initNaverMapSdk() async {
-  await dotenv.load();
   await FlutterNaverMap().init(
       clientId: 'aazbk1nhu2',
 
@@ -55,10 +54,8 @@ Future<void> initNaverMapSdk() async {
 
 Future<void> main() async {
 
-  // //네이버맵 초기화
-  // WidgetsFlutterBinding.ensureInitialized();
-  // await initNaverMapSdk();
-
+  // dotenv 사용을 위한 초기화 코드
+  await dotenv.load();
   runApp(const MyApp());
 }
 

--- a/lib/mainscreen.dart
+++ b/lib/mainscreen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'pages/add_page/add_page_1.dart';
+import 'pages/add_page/add_page_0.dart';
 import 'pages/home_page/home_page.dart';
 import 'pages/my_page/my_page.dart';
 import 'pages/plan_page/plan_page.dart';
@@ -30,7 +30,7 @@ class _MainScreenState extends State<MainScreen> {
         username: widget.username,
         welcome_message: widget.welcome_message),
     const PlanPage(),
-    const AddPage(),
+    AddPage_0(),
     const MyPage(),
   ];
 

--- a/lib/pages/add_page/add_page_0.dart
+++ b/lib/pages/add_page/add_page_0.dart
@@ -1,0 +1,153 @@
+import 'package:alpha_fe/pages/add_page/add_page_1.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../../components/app_bar.dart';
+
+// TODO: 여행 이름과 날짜를 확정짓고 '다음' 을 눌러 여행 id가 발급된 상태에서 다른 탭으로 전환할 때 별도의 처리가 필요(무분별한 여행 id 생성 방지)
+// 본 페이지에서 발급받은 tour_id 값은 최종 여행 등록에 필요하므로 모든 연결된 페이지에 인자값으로 전달됨
+
+// 추가 탭 0번째 페이지: 여행 이름과 날짜 입력
+class AddPage_0 extends StatefulWidget {
+
+  @override
+  _AddPage_0State createState() => _AddPage_0State();
+}
+
+class _AddPage_0State extends State<AddPage_0> {
+
+  // 여행 이름 입력을 위한 컨트롤러
+  final TextEditingController _titleController = TextEditingController();
+
+  // 선택한 여행 날짜를 저장할 변수
+  DateTimeRange? _selectedDateRange;
+
+  // 발급받은 여행 ID를 저장할 변수
+  late int _tourId;
+
+  // 여행 날짜 선택 다이얼로그 호출
+  Future<void> _selectDateRange() async {
+    final DateTimeRange? picked = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 365*5)),
+    );
+
+    if (picked != null) {
+      setState(() {
+        _selectedDateRange = picked;
+      });
+    }
+  }
+
+  // 입력한 여행 정보로 서버에 여행 등록 요청
+  Future<void> _registerTour() async {
+    if (_titleController.text.isEmpty || _selectedDateRange == null) {
+      // 입력값이 없으면 알림 표시
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('여행 이름과 날짜를 모두 입력해주세요')),
+      );
+      return;
+    }
+
+    final dio = Dio();
+    final url = 'http://conever.duckdns.org:8000/tour/';
+
+    try {
+      // 입력받은 2가지 데이터에 대해 POST 요청
+      final response = await dio.post(
+        url,
+        options: Options(
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ${dotenv.env['KAKAO_ACCESS_TOKEN']}'
+          }
+        ),
+        data: {
+          'tour_name': _titleController.text,
+          'start_date': '${_selectedDateRange!.start.year}-${_selectedDateRange!.start.month.toString().padLeft(2, '0')}-${_selectedDateRange!.start.day.toString().padLeft(2, '0')}',
+          'end_date': '${_selectedDateRange!.end.year}-${_selectedDateRange!.end.month.toString().padLeft(2, '0')}-${_selectedDateRange!.end.day.toString().padLeft(2, '0')}',
+        },
+      );
+
+      if (response.statusCode == 201) {
+        // 성공적으로 tour_id 발급 시 다음 페이지로 이동
+        setState(() {
+          _tourId = response.data['id'];
+        });
+
+        print(_tourId);
+
+        Navigator.push(
+          context,
+          CupertinoPageRoute(builder: (context) => AddPage_1(tourId: _tourId)),
+        );
+      } else {
+        // 등록 실패 시
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('여행 등록에 실패했습니다')),
+        );
+      }
+    } catch (e) {
+      // 요청 에러 발생 시
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('오류 발생: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('여행 정보 입력')),
+
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+
+            // 여행 이름 입력 필드
+            Text('여행 이름', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+
+            TextField(
+              controller: _titleController,
+              maxLength: 10,
+              decoration: InputDecoration(
+                hintText: '여행 이름을 입력하세요',
+              ),
+            ),
+
+            SizedBox(height: 20),
+
+            // 여행 날짜 선택 버튼
+            Text('여행 날짜', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+
+            SizedBox(height: 8),
+
+            ElevatedButton(
+              onPressed: _selectDateRange,
+              child: Text(
+                _selectedDateRange == null
+                  ? '여행 날짜 선택'
+                  : '${_selectedDateRange!.start.year}.${_selectedDateRange!.start.month}.${_selectedDateRange!.start.day} ~ ${_selectedDateRange!.end.year}.${_selectedDateRange!.end.month}.${_selectedDateRange!.end.day}'
+              ),
+            ),
+
+            Spacer(),
+
+            // 다음 버튼 - 입력받은 데이터로 tour_id 발급 및 행정구역 선택 페이지로 전환
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _registerTour,
+                child: Text('다음'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/add_page/add_page_1.dart
+++ b/lib/pages/add_page/add_page_1.dart
@@ -2,16 +2,19 @@ import 'package:flutter/material.dart';
 import '../../components/app_bar.dart';           // 공통 AppBar 컴포넌트
 import '../../components/trip_generator_card.dart';    // 여행지 선택용 드롭다운 카드
 
+// 서울시 행정구역 목록
 const List<String> districts = [
   "강남구", "강동구", "강북구", "강서구", "관악구", "광진구", "구로구", "금천구", "노원구",
   "도봉구", "동대문구", "동작구", "마포구", "서대문구", "서초구", "성동구", "성북구",
   "송파구", "양천구", "영등포구", "용산구", "은평구", "종로구", "중구", "중랑구"
 ];
 
-class AddPage extends StatelessWidget {
-  // 서울시 행정구역 목록
-
-  const AddPage({Key? key}) : super(key: key);
+class AddPage_1 extends StatelessWidget {
+  final int tourId;
+  const AddPage_1({
+    required this.tourId,
+    Key? key
+  }) : super(key: key);
 
 
   @override
@@ -52,7 +55,7 @@ class AddPage extends StatelessWidget {
               SizedBox(height: 50),
 
               // 행정구역 목록에 있는 요소들에 대해 GeneratorItem 생성
-              ...districts.map((name) => GeneratorItem(title: name)).toList(),
+              ...districts.map((name) => GeneratorItem(title: name, tourId: tourId)).toList(),
             ],
           ),
         ),

--- a/lib/pages/add_page/add_page_2.dart
+++ b/lib/pages/add_page/add_page_2.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:dio/dio.dart';
 import 'add_page_3.dart';
 import '../../components/app_bar.dart';
 import '../../components/proceed_button.dart';
@@ -12,8 +14,13 @@ import '../../components/placeinput_card.dart';
 
 class AddPage_2 extends StatefulWidget {
   final String title;
+  final int tourId;
 
-  const AddPage_2({required this.title, Key? key}) : super(key: key);
+  const AddPage_2({
+    required this.title,
+    required this.tourId,
+    Key? key
+  }) : super(key: key);
 
   @override
   State<AddPage_2> createState() => _AddPage_2State();
@@ -108,6 +115,95 @@ class _AddPage_2State extends State<AddPage_2> {
       );
       _isAddingPlace = false;
     });
+  }
+
+  //
+  Future<void> saveTourCourse() async {
+    final dio = Dio();
+    final baseUrl = 'http://conever.duckdns.org:8000';
+
+    try {
+      // tour_id값을 이용해 여행 시작 날짜 불러옴
+      final startDateResponse = await dio.get(
+          '$baseUrl/tour/${widget.tourId}/',
+          options: Options(
+            headers: {
+              'Authorization': 'Bearer ${dotenv.env['KAKAO_ACCESS_TOKEN']}'
+            }
+          )
+
+      );
+      final startDate = startDateResponse.data['start_date'];
+
+      // 등록할 JSON 데이터의 places 인자에 들어갈 데이터 생성
+      final List<Map<String, dynamic>> courseData = _placeWidgets.map((place) => {
+        'name': '<${place.title}>',
+        'mapX': place.mapX,
+        'mapY': place.mapY,
+        'image': place.imageUrl,
+        'road_address': '<${place.description}>'
+      }).toList();
+
+      // 내 여행 경로 저장
+      final response = await dio.post(
+        '$baseUrl/tour/course/',
+        data: {
+          'tour_id': '${widget.tourId}',
+          'date': startDate,
+          'places': courseData
+        },
+      options: Options(
+      headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ${dotenv.env['KAKAO_ACCESS_TOKEN']}'
+          },
+        ),
+      );
+
+      print(response);
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        // 성공 시 다음 페이지로 이동
+        Navigator.push(
+          context,
+          CupertinoPageRoute(
+            builder: (_) => AddPage_3(
+              message: "여행 저장 성공, tourId = ${widget.tourId}",
+            ),
+          ),
+        );
+      } else {
+        print('등록 실패');
+      }
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  // PlaceInfoBlock 목록 상단에 표시되는 안내 문구
+  Widget _buildTitleBlock() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text("📍${widget.title}", style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+            const SizedBox(width: 10),
+            const Text('근처 코스를 알려드릴게요', style: TextStyle(fontSize: 14, color: Color(0xFF757575))),
+          ],
+        ),
+        const SizedBox(height: 8),
+        const Row(
+          children: [
+            Text('최근 업데이트', style: TextStyle(fontSize: 11, fontWeight: FontWeight.bold, color: Color(0xFF7F7F7F))),
+            SizedBox(width: 5),
+
+            // TODO: 최근 업데이트 날짜 구현 필요
+            Text('2025.00.00', style: TextStyle(fontSize: 11, color: Color(0xFF7F7F7F))),
+          ],
+        ),
+      ],
+    );
   }
 
   @override
@@ -209,12 +305,8 @@ class _AddPage_2State extends State<AddPage_2> {
                         fontWeight_: FontWeight.bold,
                         padding_: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 12.0),
                         onTap: () {
-                          Navigator.push(
-                            context,
-                            CupertinoPageRoute(
-                              builder: (_) => AddPage_3(),
-                            ),
-                          );
+                          // 최종 경로 확정
+                          saveTourCourse();
                         },
                       ),
                     ),
@@ -228,29 +320,7 @@ class _AddPage_2State extends State<AddPage_2> {
     );
   }
 
-  // PlaceInfoBlock 목록 상단에 표시되는 안내 문구
-  Widget _buildTitleBlock() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Text("📍${widget.title}", style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
-            const SizedBox(width: 10),
-            const Text('근처 코스를 알려드릴게요', style: TextStyle(fontSize: 14, color: Color(0xFF757575))),
-          ],
-        ),
-        const SizedBox(height: 8),
-        const Row(
-          children: [
-            Text('최근 업데이트', style: TextStyle(fontSize: 11, fontWeight: FontWeight.bold, color: Color(0xFF7F7F7F))),
-            SizedBox(width: 5),
 
-            // TODO: 최근 업데이트 날짜 구현 필요
-            Text('2025.00.00', style: TextStyle(fontSize: 11, color: Color(0xFF7F7F7F))),
-          ],
-        ),
-      ],
-    );
-  }
+
+
 }

--- a/lib/pages/add_page/add_page_3.dart
+++ b/lib/pages/add_page/add_page_3.dart
@@ -2,15 +2,19 @@ import 'package:flutter/material.dart';
 import '../../components/app_bar.dart';
 
 class AddPage_3 extends StatelessWidget {
-  const AddPage_3({Key? key}) : super(key: key);
+  final String message; // 정상 등록 여부 확인 텍스트
+  const AddPage_3({
+    required this.message,
+    Key? key
+  }) : super(key: key);
 
-  // "이 코스로 할게요!" 버튼 탭할 시 연결되어야 할 페이지
+  // "이 코스로 할게요!" 버튼 탭할 시 연결되어야 할 페이지, 경로 확정됨
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const DefaultAppBar(title: "추가페이지_3rd"),
       body: Center(
-        child: Text("컨텐츠 영역"),
+        child: Text(message),
       ),
     );
   }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
#27 
## ✨ 작업내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- add_page_0.dart 추가 : 사용자로부터 여행 이름, 여행 기간 입력받음, tour_id를 발급받는 페이지
- add_page_2.dart 등 기존 코드들 수정 : 최종적으로 여행코스를 확정하기 위해 tour_id값이 필요, 연결된 페이지들에 tour_id값 넘겨주도록 코드 수정
- add_page_2.dart 에서 여행 경로를 등록하고, add_page_3.dart는 결과 확인용 페이지로 사용됨
### 스크린샷 (선택)
<!--스크린샷을 남겨서 PR에 도움을 줄 수 있다면 스크린샷을 넣어주시는 것을 권장드립니다.-->

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 개인의 .env 파일 수정 필요 <- 추후 .env에서 불러오는 것이 아닌 다른 처리방식 사용 필요함
> KAKAO_ACCESS_TOKEN=(개인 ACCESS 토큰값)