### PR TITLE
[MODIFY]: homepage 위젯 분리, viewmodel 분리

### DIFF
--- a/lib/mainscreen.dart
+++ b/lib/mainscreen.dart
@@ -23,7 +23,7 @@ class _MainScreenState extends State<MainScreen> {
   // 하단 탭에 연결될 페이지 목록
   List<Widget> get _pages => [
 
-    HomePage(accessToken: widget.accessToken,),
+    HomePage(),
     PlanPage(accessToken: widget.accessToken,),
     AddPage_0(accessToken: widget.accessToken,),
     kIsWeb ? MyPage_Web() : MyPage(accessToken: widget.accessToken,),

--- a/lib/pages/home_page/home_page.dart
+++ b/lib/pages/home_page/home_page.dart
@@ -1,107 +1,46 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import '../../components/app_bar.dart';
-import '../../components/plan_card.dart'; // 여행 계획 카드 컴포넌트
-import '../../components/placeinfo_card.dart';
 import '../../components/proceed_button.dart'; // 버튼 컴포넌트
-import '../add_page/add_page_0/add_page_0.dart';
-import '../add_page/add_page_2/add_page_2.dart';
-import '../add_page/add_page_3/add_page_3.dart';
-import 'home_page_view_model/plan_view_model.dart';
-import 'home_page_view_model/recommend_place_view_model.dart';
+import 'home_page_view_model/home_page_view_model.dart';
+import 'widgets/greeting_header.dart';
+import 'widgets/upcoming_plan_section.dart';
+import 'widgets/trending_place_section.dart';
+import '../../providers/auth_provider.dart';
 
 class HomePage extends StatefulWidget {
-  final String? accessToken;
-  const HomePage({super.key, required this.accessToken});
+  const HomePage({super.key});
 
   @override
-  _HomePageState createState() => _HomePageState();
+  State<HomePage> createState() => _HomePageState();
 }
 
 class _HomePageState extends State<HomePage> {
-  final ScrollController _scrollController = ScrollController();
-
-  String? _currentUsername;
-
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      Provider.of<PlanViewModel>(context, listen: false).fetchPlans(context);
-      Provider.of<RecommendPlaceViewModel>(context, listen: false).fetchRecommendation(context);
+    Future.microtask(() {
+      context.read<HomePageViewModel>().initialize(context);
     });
-  }
-
-  void _scrollToBottom() {
-    _scrollController.animateTo(
-      _scrollController.position.maxScrollExtent,
-      duration: const Duration(milliseconds: 500),
-      curve: Curves.easeInOut,
-    );
-  }
-
-  // PlanCard와 동일 크기의 빈 카드 UI, 탭 시 새 여행 생성 페이지로 이동
-  Widget _buildEmptyPlanCard(double width, double height) {
-    return GestureDetector(
-      onTap: () {
-        Navigator.push(
-          context,
-          CupertinoPageRoute(
-            builder: (_) => AddPage_0(accessToken: widget.accessToken,),
-          ),
-        );
-      },
-      child: Container(
-        width: width * 0.8,
-        height: height * 0.394,
-        decoration: BoxDecoration(
-          color: Color(0xFFF5F5F5),
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.add, size: 37.5, color: Color(0xFFB5B5B5),),
-              SizedBox(height: height * 0.01),
-              const Text(
-                '이런, 여행이 없어요🧐',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Color(0xFFB5B5B5),
-                ),
-              ),
-              const Text(
-                '여행을 추가해주세요!',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Color(0xFFB5B5B5),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 
   @override
   Widget build(BuildContext context) {
-    final recommendedPlace = context.watch<RecommendPlaceViewModel>().recommendedPlace;
-    final username = context.watch<PlanViewModel>().currentUsername;
-    final nearestPlan = context.watch<PlanViewModel>().nearestPlan;
-    final isLoading = context.watch<PlanViewModel>().isLoading;
+    final viewModel = context.watch<HomePageViewModel>();
+    final recommendedPlace = viewModel.recommendedPlace(context);
+    final nearestPlan = viewModel.nearestPlan(context);
+    final username = viewModel.username(context);
+    final sigunguText = viewModel.sigunguText(context);
+    final isLoading = viewModel.isLoading(context);
+    final accessToken = context.read<AuthProvider>().accessToken;
     final height = MediaQuery.of(context).size.height;
     double width = MediaQuery.of(context).size.width;
     if (kIsWeb) {
       width = 430;
     }
+
     return Scaffold(
       backgroundColor: const Color(0xFFFFFFFF),
       body: SafeArea(
@@ -113,7 +52,7 @@ class _HomePageState extends State<HomePage> {
                 children: [
                   Expanded(
                     child: SingleChildScrollView(
-                      controller: _scrollController,
+                      controller: viewModel.scrollController,
                       physics: const NeverScrollableScrollPhysics(),
                       child: Padding(
                         padding: EdgeInsets.symmetric(
@@ -123,80 +62,14 @@ class _HomePageState extends State<HomePage> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             SizedBox(height: height * 0.024),
-                            Row(
-                              crossAxisAlignment: CrossAxisAlignment.baseline,
-                              textBaseline: TextBaseline.alphabetic,
-                              children: [
-                                Text(
-                                  username ?? '',
-                                  style: const TextStyle(
-                                    fontWeight: FontWeight.w900,
-                                    fontSize: 28,
-                                  ),
-                                ),
-                                const Text(
-                                  '님',
-                                  style: TextStyle(
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 20,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const Text(
-                                "오늘도 좋은 하루에요 👋",
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 21,
-                                )
-                            ),
+                            GreetingHeader(username: username),
                             SizedBox(height: height * 0.024),
-                            const Text(
-                              '⏰ 다가오는 일정',
-                              style: TextStyle(
-                                fontSize: 28,
-                                fontWeight: FontWeight.w900,
-                              ),
-                            ),
-                            SizedBox(height: height * 0.012),
-                            // ⬇️ PlanCard 위젯: 여행 카드의 크기를 반응형으로 지정, _nearestPlan에서 동적 데이터 사용
-                            Center(
-                              // 로딩 중에는 PlanCard와 동일한 디자인의 빈 카드 표시
-                              child: isLoading
-                                  ? // 로딩 플레이스홀더
-                              SizedBox(
-                                width: width * 0.8,
-                                height: height * 0.394,
-                                child: Card(
-                                  clipBehavior: Clip.antiAlias,
-                                  color: const Color(0xFFF5F5F5),
-                                  elevation: 4,
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(12),
-                                  ),
-                                  child: Padding(
-                                    padding: EdgeInsets.fromLTRB(
-                                      width * 0.05,
-                                      height * 0.05,
-                                      width * 0.05,
-                                      height * 0.05,
-                                    ),
-                                  ),
-                                ),
-                              )
-                                  : (
-                                      nearestPlan != null
-                                          ? PlanCard(
-                                              title: nearestPlan['title']!,
-                                              startDate: nearestPlan['start_date']!,
-                                              endDate: nearestPlan['end_date']!,
-                                              size_h: height * 0.394,
-                                              size_w: width * 0.8,
-                                              tour_id: nearestPlan['id']!,
-                                              accessToken: widget.accessToken,
-                                            )
-                                          : _buildEmptyPlanCard(width, height)
-                                    ),
+                            UpcomingPlanSection(
+                              isLoading: isLoading,
+                              nearestPlan: nearestPlan,
+                              width: width,
+                              height: height,
+                              accessToken: accessToken,
                             ),
                             SizedBox(height: height * 0.06),
                             Center(
@@ -206,10 +79,11 @@ class _HomePageState extends State<HomePage> {
                                 text: "✨ 새로운 장소 탐험하기",
                                 fontSize_: 15,
                                 fontWeight_: FontWeight.bold,
-                                onTap: _scrollToBottom,
+                                onTap: () {
+                                  viewModel.scrollToBottom();
+                                },
                               ),
                             ),
-                            // 트렌딩 버튼 하단에 여백 추가
                             SizedBox(height: height * 0.11),
                             Padding(
                               padding: EdgeInsets.symmetric(horizontal: width * 0.02),
@@ -222,162 +96,22 @@ class _HomePageState extends State<HomePage> {
                               ),
                             ),
                             SizedBox(height: height * 0.04),
-                            // 장소 추천 영역: 단일 Column으로 조건부 children 렌더링
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                          if (recommendedPlace != null) ...[
-                                  ClipRRect(
-                                    borderRadius: BorderRadius.circular(20),
-                                    child: recommendedPlace['image1'] != 'ERROR'
-                                        ? Image.network(
-                                            recommendedPlace['image1'],
-                                            width: width * 0.87,
-                                            height: height * 0.25,
-                                            fit: BoxFit.cover,
-                                            errorBuilder: (context, error, stackTrace) {
-                                              return Container(
-                                                width: width * 0.87,
-                                                height: height * 0.25,
-                                                decoration: BoxDecoration(
-                                                  color: Colors.grey.shade300,
-                                                  borderRadius: BorderRadius.circular(20),
-                                                ),
-                                                child: Center(
-                                                  child: Icon(
-                                                    Icons.broken_image,
-                                                    size: width * 0.093,
-                                                    color: Colors.grey,
-                                                  ),
-                                                ),
-                                              );
-                                            },
-                                          )
-                                        : Container(
-                                            width: width * 0.87,
-                                            height: height * 0.25,
-                                            decoration: BoxDecoration(
-                                              color: Colors.grey.shade300,
-                                              borderRadius: BorderRadius.circular(20),
-                                            ),
-                                            child: Center(
-                                              child: Icon(
-                                                Icons.broken_image,
-                                                size: width * 0.093,
-                                                color: Colors.grey,
-                                              ),
-                                            ),
-                                          ),
-                                  ),
-                                  SizedBox(height: height * 0.015),
-                                  Row(
-                                    children: [
-                                      const Icon(Icons.location_on, size: 17, color: Colors.black),
-                                      SizedBox(width: width * 0.013),
-                                      Text(
-                                        recommendedPlace['title'],
-                                        style: const TextStyle(
-                                          fontSize: 15,
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                  SizedBox(height: height * 0.007),
-                                  Padding(
-                                    padding: EdgeInsets.only(left: width * 0.053),
-                                    child: Text(
-                                      (recommendedPlace['title'] != null && recommendedPlace['address'] != null && (recommendedPlace['address'] as String).split(' ').length > 1)
-                                          ? "${recommendedPlace['title']}은(는) ${(recommendedPlace['address'] as String).split(' ')[1]}의 관광지 입니다.\n${_currentUsername ?? ''} 님의 마음에 드셨으면 좋겠네요!"
-                                          : '',
-                                      style: TextStyle(
-                                        fontSize: 13,
-                                        color: Colors.grey[700],
-                                      ),
-                                    ),
-                                  ),
-                                  SizedBox(height: height * 0.017),
-                                  Center(
-                                    child: ProceedButton(
-                                      size_w: width * 0.5,
-                                      size_h: height * 0.05,
-                                      text: (recommendedPlace['address'] != null && (recommendedPlace['address'] as String).split(' ').length > 1)
-                                          ? "${(recommendedPlace['address'] as String).split(' ')[1]} 코스 생성하기"
-                                          : "코스 생성하기",
-                                      fontSize_: 13,
-                                      fontWeight_: FontWeight.bold,
-                                      onTap: () async {
-                                        final String sigun = (recommendedPlace['address'] != null && (recommendedPlace['address'] as String).split(' ').length > 1)
-                                            ? (recommendedPlace['address'] as String).split(' ')[1]
-                                            : '';
-                                        Navigator.of(context).push(
-                                          CupertinoPageRoute(
-                                            builder: (_) => AddPage_0(
-                                                accessToken: widget.accessToken,
-                                                sigun: sigun,
-                                            ),
-                                          ),
-                                        );
-                                      },
-                                    ),
-                                  ),
-                                ] else ...[
-                                  ClipRRect(
-                                    borderRadius: BorderRadius.circular(20),
-                                    child: Container(
-                                      width: width * 0.87,
-                                      height: height * 0.25,
-                                      color: Colors.grey[300],
-                                    ),
-                                  ),
-                                  SizedBox(height: height * 0.015),
-                                  Container(
-                                    width: width * 0.87,
-                                    height: height * 0.08,
-                                    padding: EdgeInsets.symmetric(
-                                      horizontal: width * 0.04,
-                                      vertical: height * 0.012,
-                                    ),
-                                    decoration: const BoxDecoration(
-                                      color: Color(0xFFFFFFFF),
-                                    ),
-                                    child: Align(
-                                      alignment: Alignment.centerLeft,
-                                      child: Text(
-                                        '트렌딩 페이지 정보를 받아오고 있습니다...',
-                                        style: TextStyle(
-                                          fontSize: 13,
-                                          color: Colors.grey[600],
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  SizedBox(height: height * 0.017),
-                                  Center(
-                                    child: ProceedButton(
-                                      size_w: width * 0.5,
-                                      size_h: height * 0.05,
-                                      text: '가져오는 중...',
-                                      fontSize_: 13,
-                                      fontWeight_: FontWeight.bold,
-                                      onTap: () {},
-                                    ),
-                                  ),
-                                ],
-                              ],
+                            TrendingPlaceSection(
+                              recommendedPlace: recommendedPlace,
+                              sigunguText: sigunguText,
+                              username: username,
+                              width: width,
+                              height: height,
+                              accessToken: accessToken,
+                              onTap: () {
+                                viewModel.handleTrendingPlaceTap(context, accessToken);
+                              },
                             ),
-
                             SizedBox(height: height * 0.01),
-
-                            // 맨 상단으로 되돌아가기 버튼
                             Center(
                               child: TextButton.icon(
                                 onPressed: () {
-                                  _scrollController.animateTo(
-                                    0,
-                                    duration: const Duration(milliseconds: 500),
-                                    curve: Curves.easeInOut,
-                                  );
+                                  viewModel.scrollToTop();
                                 },
                                 icon: Icon(
                                   Icons.arrow_drop_up,
@@ -408,9 +142,8 @@ class _HomePageState extends State<HomePage> {
                 ],
               ),
             ),
-            // 행정구역 검색 기능을 제공하는 앱바, 오버레이 리스트와 연결됨
             SearchAppBar(
-              accessToken: widget.accessToken,
+              accessToken: accessToken,
             ),
           ],
         ),

--- a/lib/pages/home_page/home_page_view_model/home_page_view_model.dart
+++ b/lib/pages/home_page/home_page_view_model/home_page_view_model.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:alpha_fe/pages/add_page/add_page_0/add_page_0.dart';
+import 'plan_view_model.dart';
+import 'recommend_place_view_model.dart';
+import 'package:provider/provider.dart';
+
+class HomePageViewModel extends ChangeNotifier {
+  final ScrollController scrollController = ScrollController();
+
+  /// 최초 진입 시 사용자 이름, 여행 계획, 추천 장소를 요청
+  void initialize(BuildContext context) {
+    context.read<PlanViewModel>().fetchPlans(context);
+    context.read<RecommendPlaceViewModel>().fetchRecommendation(context);
+  }
+
+  /// getter로 View에 제공
+  Map<String, dynamic>? recommendedPlace(BuildContext context) =>
+      context.read<RecommendPlaceViewModel>().recommendedPlace;
+  Map<String, dynamic>? nearestPlan(BuildContext context) =>
+      context.read<PlanViewModel>().nearestPlan;
+
+  String? username(BuildContext context) =>
+      context.read<PlanViewModel>().currentUsername;
+
+  bool isLoading(BuildContext context) =>
+      context.read<PlanViewModel>().isLoading;
+
+  String sigunguText(BuildContext context) {
+    final address = recommendedPlace(context)?['address'] ?? '';
+    if (address is String && address.split(' ').length > 1) {
+      return address.split(' ')[1];
+    }
+    return '';
+  }
+
+  /// 트렌딩 버튼 탭 시 AddPage_0으로 이동
+  void handleTrendingPlaceTap(BuildContext context, String? accessToken) {
+    Navigator.of(context).push(
+      CupertinoPageRoute(
+        builder: (_) => AddPage_0(
+          accessToken: accessToken,
+          sigun: sigunguText(context),
+        ),
+      ),
+    );
+  }
+
+  void scrollToBottom() {
+    scrollController.animateTo(
+      scrollController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 500),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void scrollToTop() {
+    scrollController.animateTo(
+      0,
+      duration: const Duration(milliseconds: 500),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/pages/home_page/widgets/greeting_header.dart
+++ b/lib/pages/home_page/widgets/greeting_header.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class GreetingHeader extends StatelessWidget {
+  final String? username;
+
+  const GreetingHeader({super.key, required this.username});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            Text(
+              username ?? '',
+              style: const TextStyle(
+                fontWeight: FontWeight.w900,
+                fontSize: 28,
+              ),
+            ),
+            const Text(
+              '님',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 20,
+              ),
+            ),
+          ],
+        ),
+        const Text(
+          "오늘도 좋은 하루에요 👋",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 21,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/home_page/widgets/trending_place_section.dart
+++ b/lib/pages/home_page/widgets/trending_place_section.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import '../../../components/proceed_button.dart';
+
+class TrendingPlaceSection extends StatelessWidget {
+  final Map<String, dynamic>? recommendedPlace;
+  final String sigunguText;
+  final String? username;
+  final double width;
+  final double height;
+  final String? accessToken;
+  final VoidCallback onTap;
+
+  const TrendingPlaceSection({
+    super.key,
+    required this.recommendedPlace,
+    required this.sigunguText,
+    required this.username,
+    required this.width,
+    required this.height,
+    required this.accessToken,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (recommendedPlace != null) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(20),
+            child: Image.network(
+              recommendedPlace!['image1'],
+              width: width * 0.87,
+              height: height * 0.25,
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) => _errorImageBox(),
+            ),
+          ),
+          SizedBox(height: height * 0.015),
+          Row(
+            children: [
+              const Icon(Icons.location_on, size: 17),
+              SizedBox(width: width * 0.013),
+              Text(
+                recommendedPlace!['title'],
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: height * 0.007),
+          Padding(
+            padding: EdgeInsets.only(left: width * 0.053),
+            child: Text(
+              "$sigunguText의 관광지인 ${recommendedPlace!['title']}!\n${username ?? ''} 님의 취향에 맞을지도 몰라요.",
+              style: TextStyle(fontSize: 13, color: Colors.grey[700]),
+            ),
+          ),
+          SizedBox(height: height * 0.017),
+          Center(
+            child: ProceedButton(
+              size_w: width * 0.5,
+              size_h: height * 0.05,
+              text: "$sigunguText 코스 생성하기",
+              fontSize_: 13,
+              fontWeight_: FontWeight.bold,
+              onTap: onTap,
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Column(
+      children: [
+        _errorImageBox(),
+        SizedBox(height: height * 0.015),
+        Text('트렌딩 데이터를 불러오는 중입니다...', style: TextStyle(fontSize: 13, color: Colors.grey[600])),
+        SizedBox(height: height * 0.017),
+        Center(
+          child: ProceedButton(
+            size_w: width * 0.5,
+            size_h: height * 0.05,
+            text: '가져오는 중...',
+            fontSize_: 13,
+            fontWeight_: FontWeight.bold,
+            onTap: () {},
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _errorImageBox() {
+    return Container(
+      width: width * 0.87,
+      height: height * 0.25,
+      decoration: BoxDecoration(
+        color: Colors.grey.shade300,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: const Center(
+        child: Icon(Icons.broken_image, size: 40, color: Colors.grey),
+      ),
+    );
+  }
+}

--- a/lib/pages/home_page/widgets/upcoming_plan_section.dart
+++ b/lib/pages/home_page/widgets/upcoming_plan_section.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../../../components/plan_card.dart';
+import '../../../pages/add_page/add_page_0/add_page_0.dart';
+
+class UpcomingPlanSection extends StatelessWidget {
+  final bool isLoading;
+  final Map<String, dynamic>? nearestPlan;
+  final double width;
+  final double height;
+  final String? accessToken;
+
+  const UpcomingPlanSection({
+    super.key,
+    required this.isLoading,
+    required this.nearestPlan,
+    required this.width,
+    required this.height,
+    required this.accessToken,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '⏰ 다가오는 일정',
+          style: TextStyle(
+            fontSize: 28,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        SizedBox(height: height * 0.012),
+        Center(
+          child: _buildCard(context),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCard(BuildContext context) {
+    if (isLoading) {
+      return SizedBox(
+        width: width * 0.8,
+        height: height * 0.394,
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          color: const Color(0xFFF5F5F5),
+          elevation: 4,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+      );
+    }
+
+    if (nearestPlan != null) {
+      return PlanCard(
+        title: nearestPlan!['title'],
+        startDate: nearestPlan!['start_date'],
+        endDate: nearestPlan!['end_date'],
+        size_h: height * 0.394,
+        size_w: width * 0.8,
+        tour_id: nearestPlan!['id'],
+        accessToken: accessToken,
+      );
+    }
+
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          CupertinoPageRoute(
+            builder: (_) => AddPage_0(accessToken: accessToken),
+          ),
+        );
+      },
+      child: Container(
+        width: width * 0.8,
+        height: height * 0.394,
+        decoration: BoxDecoration(
+          color: const Color(0xFFF5F5F5),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: const Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.add, size: 37.5, color: Color(0xFFB5B5B5)),
+              SizedBox(height: 10),
+              Text(
+                '이런, 여행이 없어요🧐',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFFB5B5B5),
+                ),
+              ),
+              Text(
+                '여행을 추가해주세요!',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFFB5B5B5),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -9,9 +9,12 @@ import 'package:alpha_fe/services/websocket/show_tour_course/show_tour_course_ap
 import 'package:alpha_fe/services/websocket/show_tour_course/show_tour_course_websocket.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
+import 'package:alpha_fe/pages/home_page/home_page_view_model/home_page_view_model.dart';
+
 
 
 List<SingleChildWidget> appProviders = [
+  ChangeNotifierProvider(create: (_) => HomePageViewModel()),
   ChangeNotifierProvider(create: (_) => AuthProvider()),
   ChangeNotifierProvider(create: (_) => PlanViewModel()),
   ChangeNotifierProvider(create: (_) => LoadingViewModel()),


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#124 

## ✨ 작업내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
homepage 위젯 분리
- 환영 메세지, PlanCard, 트렌딩 장소 섹션 별도의 위젯 파일로 분리

homepage view-viewmodel 분리
- homepageViewModel에서 다른 모든 ViewModel들을 구독하도록 구조 수정
- home_page.dart는 불필요한 부분들 외에는 UI만 표시하도록 함

### 스크린샷 (선택)
<!--스크린샷을 남겨서 PR에 도움을 줄 수 있다면 스크린샷을 넣어주시는 것을 권장드립니다.-->

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말