### PR TITLE
[MODIFY]: AddPage, HomePage 및 관련 컴포넌트 구조 개선

### DIFF
--- a/lib/components/app_bar.dart
+++ b/lib/components/app_bar.dart
@@ -170,7 +170,6 @@ class _SearchAppBarState extends State<SearchAppBar> {
                               CupertinoPageRoute(
                                 builder: (_) => AddPage_0(
                                   sigun: gu,
-                                  accessToken: widget.accessToken,
                                 ),
                               ),
                             ).then((_) {

--- a/lib/components/trip_generator_card.dart
+++ b/lib/components/trip_generator_card.dart
@@ -6,21 +6,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import '../pages/add_page/add_page_2/add_page_2.dart';
 
+
 class GeneratorItem extends StatelessWidget {
-  final String? accessToken;
   final String title;
   final int tourId;
 
   const GeneratorItem({
     required this.title,
     required this.tourId,
-    Key? key, required this.accessToken,
+    Key? key,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final height = MediaQuery.of(context).size.height;
     double width = MediaQuery.of(context).size.width;
+
     if (kIsWeb) {
       width = 430;
     }
@@ -39,7 +40,6 @@ class GeneratorItem extends StatelessWidget {
                 builder: (context) => AddPage_2(
                   title: title,
                   tourId: tourId,
-                  accessToken: accessToken,
                 ),
               ),
             );

--- a/lib/mainscreen.dart
+++ b/lib/mainscreen.dart
@@ -25,7 +25,7 @@ class _MainScreenState extends State<MainScreen> {
 
     HomePage(),
     PlanPage(accessToken: widget.accessToken,),
-    AddPage_0(accessToken: widget.accessToken,),
+    AddPage_0(),
     kIsWeb ? MyPage_Web() : MyPage(accessToken: widget.accessToken,),
 
   ];

--- a/lib/pages/add_page/add_page_0/add_page_0.dart
+++ b/lib/pages/add_page/add_page_0/add_page_0.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-
+import 'package:alpha_fe/components/custom_alert_dialog.dart';
 import '../../../components/proceed_button.dart';
 import '../../../components/app_bar.dart';
 import 'package:alpha_fe/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart';
@@ -94,7 +94,22 @@ class _AddPage_0State extends State<AddPage_0> {
                     text: "새 여행 만들기",
                     fontSize_: 18.5,
                     fontWeight_: FontWeight.bold,
-                    onTap: () => viewModel.createTour(context, widget.sigun),
+                    onTap: () {
+                      final success = viewModel.createTour(
+                        context: context,
+                        sigun: widget.sigun,
+                      );
+
+                      if (!success) {
+                        showDialog(
+                          context: context,
+                          builder: (context) => const CustomAlertDialog(
+                            title: '입력 오류',
+                            contentText: '여행 이름(10자 이내)과 날짜를 모두 입력해주세요',
+                          ),
+                        );
+                      }
+                    },
                   ),
                 ),
               ),

--- a/lib/pages/add_page/add_page_0/add_page_0.dart
+++ b/lib/pages/add_page/add_page_0/add_page_0.dart
@@ -1,6 +1,7 @@
 import 'package:alpha_fe/pages/add_page/add_page_0/view_model/tour_create_view_model.dart';
 import 'package:alpha_fe/pages/add_page/add_page_1/add_page_1.dart';
 import 'package:alpha_fe/pages/add_page/add_page_2/add_page_2.dart';
+import 'package:alpha_fe/providers/auth_provider.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -8,15 +9,13 @@ import 'package:provider/provider.dart';
 import '../../../components/custom_alert_dialog.dart';
 import '../../../components/proceed_button.dart';
 import '../../../components/app_bar.dart';
+import 'package:alpha_fe/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart';
 
-
-// 본 페이지에서 발급받은 tour_id 값은 최종 여행 등록에 필요하므로 모든 연결된 페이지에 인자값으로 전달됨
 
 // 추가 탭 0번째 페이지: 여행 이름과 날짜 입력
 class AddPage_0 extends StatefulWidget {
-  final String? accessToken;
   final String? sigun;
-  const AddPage_0({Key? key, this.sigun, required this.accessToken}) : super(key: key);
+  const AddPage_0({Key? key, this.sigun}) : super(key: key);
 
   @override
   _AddPage_0State createState() => _AddPage_0State();
@@ -24,233 +23,16 @@ class AddPage_0 extends StatefulWidget {
 
 class _AddPage_0State extends State<AddPage_0> {
 
-  // 여행 이름 입력을 위한 컨트롤러
-  final TextEditingController _titleController = TextEditingController();
-
-  // 선택한 여행 날짜를 저장할 변수
-  DateTimeRange? _selectedDateRange;
-
-  // 발급받은 여행 ID를 저장할 변수
-  late int _tourId;
-
-  bool _tourRegistered = false; // 여행 생성 상태 여부 확인
 
   @override
   void initState() {
     super.initState();
-    _tourId = 0;
   }
 
-  // 여행 날짜 선택 다이얼로그 호출
-  Future<void> _selectDateRange() async {
-    final DateTime now = DateTime.now();
-    final DateTimeRange? picked = await showDateRangePicker(
-      context: context,
-      locale: const Locale('ko', 'KR'),
-      // 날짜 범위 제한
-      firstDate: now,
-      lastDate: now.add(const Duration(days: 365 * 5)),
-      builder: (context, child) {
-        return Theme(
-          data: ThemeData(
-            brightness: Brightness.light,
-            dialogTheme: const DialogTheme(
-              backgroundColor: Colors.white,
-            ),
-            colorScheme: const ColorScheme.light(
-              primary: Color(0xFF2C2C2C),
-              onPrimary: Colors.white,
-              onSurface: Colors.black,
-              secondary: Color(0xFFFFF176), // 연노랑 (light yellow)
-            ),
-            textButtonTheme: TextButtonThemeData(
-              style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFF2C2C2C),
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(8.0)),
-                ),
-              ),
-            ),
-          ),
-          child: child!,
-        );
-      },
-    );
-
-    if (picked != null) {
-
-      // 3일 이상 선택 불가
-      if (picked.duration.inDays > 2) {
-        await showDialog(
-          context: context,
-          builder: (BuildContext context) => const CustomAlertDialog(
-            title: '안내',
-            contentText: '최대 3일까지 선택할 수 있습니다.',
-          ),
-        );
-        return;
-      }
-
-      setState(() {
-        _selectedDateRange = picked;
-      });
-    }
-  }
-
-  // // 입력한 여행 정보로 서버에 여행 등록 요청
-  // Future<void> _registerTour() async {
-  //   final accessToken = widget.accessToken;
-  //   final dio = Dio();
-  //   const url = 'http://conever.duckdns.org:8000';
-  //
-  //   // 기존 여행 중 동일한 제목과 날짜가 있는지 확인
-  //   try {
-  //     // 현재 사용자 이름 가져오기
-  //     final userResponse = await dio.get(
-  //       '$url/user/me/',
-  //       options: Options(
-  //         headers: {
-  //           'Authorization': 'Bearer $accessToken',
-  //           'Accept': 'application/json',
-  //         },
-  //       ),
-  //     );
-  //     final currentUsername = userResponse.data['username'];
-  //
-  //     // 모든 여행 목록 가져오기
-  //     final tourResponse = await dio.get(
-  //       '$url/tour/',
-  //       options: Options(
-  //         headers: {
-  //           'Authorization': 'Bearer $accessToken',
-  //           'Accept': 'application/json',
-  //         },
-  //       ),
-  //     );
-  //     final List<dynamic> allPlans = tourResponse.data;
-  //
-  //     // 현재 사용자의 여행만 필터링
-  //     final List<dynamic> userPlans = allPlans.where((plan) {
-  //       final List<dynamic> users = plan['user'] ?? [];
-  //       return users.any((u) => u['username'] == currentUsername);
-  //     }).toList();
-  //
-  //     // 입력된 제목과 날짜 포맷 생성
-  //     final String inputTitle = _titleController.text;
-  //     final String inputStart = '${_selectedDateRange!.start.year.toString().padLeft(4, '0')}-${_selectedDateRange!.start.month.toString().padLeft(2, '0')}-${_selectedDateRange!.start.day.toString().padLeft(2, '0')}';
-  //     final String inputEnd =   '${_selectedDateRange!.end.year.toString().padLeft(4, '0')}-${_selectedDateRange!.end.month.toString().padLeft(2, '0')}-${_selectedDateRange!.end.day.toString().padLeft(2, '0')}';
-  //
-  //     // 동일한 여행이 이미 존재하는지 검사
-  //     final bool exists = userPlans.any((plan) =>
-  //       plan['tour_name'] == inputTitle &&
-  //       plan['start_date'] == inputStart &&
-  //       plan['end_date'] == inputEnd
-  //     );
-  //
-  //     if (exists) {
-  //       // 이미 존재하는 여행인 경우 알림 후 종료
-  //       await showDialog(
-  //         context: context,
-  //         builder: (BuildContext dialogContext) => const CustomAlertDialog(
-  //           title: '이미 존재하는 여행입니다',
-  //           contentText: '',
-  //         ),
-  //       );
-  //       return;
-  //     }
-  //   } catch (e) {
-  //     // 예외 발생 시 로깅 후 계속 진행
-  //     print('중복 여행 확인 중 오류 발생: $e');
-  //   }
-  //
-  //   if (_titleController.text.isEmpty ||
-  //       _titleController.text.length > 10 ||
-  //       _selectedDateRange == null) {
-  //     await showDialog(
-  //       context: context,
-  //       builder: (BuildContext context) => const CustomAlertDialog(
-  //         title: '입력 오류',
-  //         contentText: '여행 이름(10자 이내)과 날짜를 모두 입력해주세요',
-  //       ),
-  //     );
-  //     return;
-  //   }
-  //
-  //   try {
-  //     // 입력받은 2가지 데이터에 대해 POST 요청
-  //     final response = await dio.post(
-  //       '$url/tour/',
-  //       options: Options(
-  //         headers: {
-  //           'Content-Type': 'application/json',
-  //           'Authorization': 'Bearer $accessToken'
-  //         }
-  //       ),
-  //       data: {
-  //         'tour_name': _titleController.text,
-  //         'start_date': '${_selectedDateRange!.start.year}-${_selectedDateRange!.start.month.toString().padLeft(2, '0')}-${_selectedDateRange!.start.day.toString().padLeft(2, '0')}',
-  //         'end_date': '${_selectedDateRange!.end.year}-${_selectedDateRange!.end.month.toString().padLeft(2, '0')}-${_selectedDateRange!.end.day.toString().padLeft(2, '0')}',
-  //       },
-  //     );
-  //
-  //     if (response.statusCode == 201) {
-  //       // 성공적으로 tour_id 발급 시 다음 페이지로 이동
-  //       setState(() {
-  //         _tourId = response.data['id'];
-  //       });
-  //       _tourRegistered = true; // 여행이 생성되었음을 표시
-  //
-  //       print(_tourId);
-  //
-  //       if (widget.onFinishCreation != null) {
-  //         // 콜백 함수가 주어진 경우 → AddPage_2로부터 이어지는 흐름 → onFinishCreation으로 tourId 전달하여 이후 saveTourCourse에 활용
-  //         widget.onFinishCreation!(_tourId);
-  //       } else {
-  //         Navigator.push(
-  //           context,
-  //           CupertinoPageRoute(builder: (context) => AddPage_1(tourId: _tourId, accessToken: widget.accessToken,)),
-  //         );
-  //       }
-  //     } else {
-  //       // 등록 실패 시
-  //       _tourRegistered = false;
-  //       await showDialog(
-  //         context: context,
-  //         builder: (BuildContext context) => const CustomAlertDialog(
-  //           title: '등록 실패',
-  //           contentText: '여행 등록에 실패했습니다',
-  //         ),
-  //       );
-  //     }
-  //   } catch (e) {
-  //     // 엑세스 토큰 만료 시 리프레시 토큰을 사용해 재발급
-  //     if (e is DioException && e.response?.statusCode == 403) {
-  //       final bool? result = await getAccessTokenFromRefreshToken();
-  //       if (result == false) {
-  //         LogoutByExpiration(context);
-  //       }
-  //       await _registerTour();
-  //       return;
-  //     }
-  //     // 요청 에러 발생 시
-  //     _tourRegistered = false;
-  //     await showDialog(
-  //       context: context,
-  //       builder: (BuildContext context) => CustomAlertDialog(
-  //         title: '예외 발생',
-  //         contentText: '오류 발생: $e',
-  //       ),
-  //     );
-  //   }
-  // }
-
-  @override
-  void dispose() {
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
+    final viewModel = context.watch<AddPage0ViewModel>();
     double width = MediaQuery.of(context).size.width;
     if (kIsWeb) {
       width = 430;
@@ -294,11 +76,14 @@ class _AddPage_0State extends State<AddPage_0> {
               SizedBox(
                 height: height * 0.06,
                 child: TextField(
-                  controller: _titleController,
+                  controller: viewModel.titleController,
                   maxLength: 10,
                   decoration: InputDecoration(
                     isDense: true,
-                    hintText: "여행에 대한 정보를 간단한 제목으로 지어보세요",
+                    hintText: viewModel.selectedDateRange == null
+                        ? ""
+                        : "${viewModel.selectedDateRange!.start.year}.${viewModel.selectedDateRange!.start.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.start.day.toString().padLeft(2, '0')} ~ "
+                        "${viewModel.selectedDateRange!.end.year}.${viewModel.selectedDateRange!.end.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.end.day.toString().padLeft(2, '0')}",
                     hintStyle: const TextStyle(
                       fontSize: 14.3,
                       color: Colors.grey,
@@ -344,10 +129,10 @@ class _AddPage_0State extends State<AddPage_0> {
                         cursorColor: const Color(0xFF2C2C2C),
                         decoration: InputDecoration(
                           isDense: true,
-                          hintText: _selectedDateRange == null
+                          hintText: viewModel.selectedDateRange == null
                               ? ""
-                              : "${_selectedDateRange!.start.year}.${_selectedDateRange!.start.month.toString().padLeft(2, '0')}.${_selectedDateRange!.start.day.toString().padLeft(2, '0')} ~ "
-                                "${_selectedDateRange!.end.year}.${_selectedDateRange!.end.month.toString().padLeft(2, '0')}.${_selectedDateRange!.end.day.toString().padLeft(2, '0')}",
+                              : "${viewModel.selectedDateRange!.start.year}.${viewModel.selectedDateRange!.start.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.start.day.toString().padLeft(2, '0')} ~ "
+                                "${viewModel.selectedDateRange!.end.year}.${viewModel.selectedDateRange!.end.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.end.day.toString().padLeft(2, '0')}",
                           hintStyle: const TextStyle(
                             fontSize: 12.3,
                             color: Colors.grey,
@@ -375,7 +160,7 @@ class _AddPage_0State extends State<AddPage_0> {
                     height: height * 0.058,
                     width: width * 0.14,
                     child: ElevatedButton(
-                      onPressed: _selectDateRange,
+                      onPressed: () => viewModel.selectDateRange(context),
                       style: ElevatedButton.styleFrom(
                         backgroundColor: const Color(0xFF2C2C2C),
                         foregroundColor: Colors.white,
@@ -413,50 +198,7 @@ class _AddPage_0State extends State<AddPage_0> {
                     text: "새 여행 만들기",
                     fontSize_: 18.5,
                     fontWeight_: FontWeight.bold,
-                    onTap: () {
-                      final title = _titleController.text;
-                      final dateRange = _selectedDateRange;
-
-                      if (title.isEmpty || title.length > 10 || dateRange == null) {
-                        showDialog(
-                          context: context,
-                          builder: (BuildContext context) => const CustomAlertDialog(
-                            title: '입력 오류',
-                            contentText: '여행 이름(10자 이내)과 날짜를 모두 입력해주세요',
-                          ),
-                        );
-                        return;
-                      }
-                      context.read<TourCreateViewModel>().registerTour(
-                        context,
-                        title,
-                        dateRange,
-                        onSuccess: (tourId) {
-                          if (widget.sigun != null) {
-                            Navigator.push(
-                                context,
-                                CupertinoPageRoute(
-                                    builder: (context) => AddPage_2(
-                                        title: widget.sigun!,
-                                        tourId: tourId,
-                                        accessToken: widget.accessToken
-                                    ),
-                                )
-                            );
-                          } else {
-                            Navigator.push(
-                              context,
-                              CupertinoPageRoute(
-                                builder: (context) => AddPage_1(
-                                  tourId: tourId,
-                                  accessToken: widget.accessToken,
-                                ),
-                              ),
-                            );
-                          }
-                        },
-                      );
-                    },
+                    onTap: () => viewModel.createTour(context, widget.sigun),
                   ),
                 ),
               ),

--- a/lib/pages/add_page/add_page_0/add_page_0.dart
+++ b/lib/pages/add_page/add_page_0/add_page_0.dart
@@ -73,11 +73,6 @@ class _AddPage_0State extends State<AddPage_0> {
                 width: width,
                 height: height,
               ),
-              SizedBox(height: height * 0.005),
-              const Text("• 한글, 영문, 특수기호 구분없이 10자 이내로 입력",
-                  style: TextStyle(fontSize: 12.3, color: Colors.grey)),
-              const Text("• 결정 후 수정할 수 없으니 신중히 정해주세요",
-                  style: TextStyle(fontSize: 12.3, color: Colors.grey)),
 
               SizedBox(height: height * 0.05),
 

--- a/lib/pages/add_page/add_page_0/add_page_0.dart
+++ b/lib/pages/add_page/add_page_0/add_page_0.dart
@@ -1,15 +1,13 @@
-import 'package:alpha_fe/pages/add_page/add_page_0/view_model/tour_create_view_model.dart';
-import 'package:alpha_fe/pages/add_page/add_page_1/add_page_1.dart';
-import 'package:alpha_fe/pages/add_page/add_page_2/add_page_2.dart';
-import 'package:alpha_fe/providers/auth_provider.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../../components/custom_alert_dialog.dart';
+
 import '../../../components/proceed_button.dart';
 import '../../../components/app_bar.dart';
 import 'package:alpha_fe/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart';
+import 'package:alpha_fe/pages/add_page/add_page_0/widgets/date_select_section.dart';
+import 'package:alpha_fe/pages/add_page/add_page_0/widgets/title_input_section.dart';
 
 
 // 추가 탭 0번째 페이지: 여행 이름과 날짜 입력
@@ -27,6 +25,10 @@ class _AddPage_0State extends State<AddPage_0> {
   @override
   void initState() {
     super.initState();
+    // ViewModel의 이전값 리셋
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<AddPage0ViewModel>().resetState();
+    });
   }
 
 
@@ -66,39 +68,10 @@ class _AddPage_0State extends State<AddPage_0> {
 
               SizedBox(height: height * 0.05),
 
-              // 여행 제목 입력 - 10글자 제한
-              const Text("✏️ 여행 제목",
-                  style: TextStyle(
-                    fontSize: 20.5,
-                    fontWeight: FontWeight.bold,
-                  )),
-              SizedBox(height: height * 0.01),
-              SizedBox(
-                height: height * 0.06,
-                child: TextField(
-                  controller: viewModel.titleController,
-                  maxLength: 10,
-                  decoration: InputDecoration(
-                    isDense: true,
-                    hintText: viewModel.selectedDateRange == null
-                        ? ""
-                        : "${viewModel.selectedDateRange!.start.year}.${viewModel.selectedDateRange!.start.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.start.day.toString().padLeft(2, '0')} ~ "
-                        "${viewModel.selectedDateRange!.end.year}.${viewModel.selectedDateRange!.end.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.end.day.toString().padLeft(2, '0')}",
-                    hintStyle: const TextStyle(
-                      fontSize: 14.3,
-                      color: Colors.grey,
-                      fontWeight: FontWeight.w400,
-                    ),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    counterText: "",
-                    contentPadding: EdgeInsets.symmetric(
-                      vertical: height * 0.02,
-                      horizontal: width * 0.03,
-                    ),
-                  ),
-                ),
+              TitleInputSection(
+                viewModel: viewModel,
+                width: width,
+                height: height,
               ),
               SizedBox(height: height * 0.005),
               const Text("• 한글, 영문, 특수기호 구분없이 10자 이내로 입력",
@@ -108,83 +81,11 @@ class _AddPage_0State extends State<AddPage_0> {
 
               SizedBox(height: height * 0.05),
 
-              // 여행 날짜 입력 - material.dart의 DateRangePicker 사용
-              const Text("✏️ 여행 날짜",
-                  style: TextStyle(
-                    fontSize: 20.5,
-                    fontWeight: FontWeight.bold,
-                  )),
-              SizedBox(height: height * 0.01),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-
-                  // 날짜 표시 필드
-                  Expanded(
-                    child: SizedBox(
-                      height: height * 0.06,
-                      child: TextField(
-                        readOnly: true,
-                        cursorColor: const Color(0xFF2C2C2C),
-                        decoration: InputDecoration(
-                          isDense: true,
-                          hintText: viewModel.selectedDateRange == null
-                              ? ""
-                              : "${viewModel.selectedDateRange!.start.year}.${viewModel.selectedDateRange!.start.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.start.day.toString().padLeft(2, '0')} ~ "
-                                "${viewModel.selectedDateRange!.end.year}.${viewModel.selectedDateRange!.end.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.end.day.toString().padLeft(2, '0')}",
-                          hintStyle: const TextStyle(
-                            fontSize: 12.3,
-                            color: Colors.grey,
-                            fontWeight: FontWeight.w400,
-                          ),
-                          filled: true,
-                          fillColor: const Color(0xFFF5F5F5),
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          counterText: "",
-                          contentPadding: EdgeInsets.symmetric(
-                            vertical: height * 0.02,
-                            horizontal: width * 0.03,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-
-                  SizedBox(width: width * 0.02),
-
-                  // 날짜 선택 버튼 - showDateRangePicker 호출
-                  SizedBox(
-                    height: height * 0.058,
-                    width: width * 0.14,
-                    child: ElevatedButton(
-                      onPressed: () => viewModel.selectDateRange(context),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF2C2C2C),
-                        foregroundColor: Colors.white,
-                        padding: EdgeInsets.zero,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      child: const Text(
-                        "🗓️",
-                        style: TextStyle(
-                          fontSize: 18.5,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              SizedBox(height: height * 0.005),
-
-              Text(
-                  "• 지금은 3일만 선택할 수 있습니다",
-                  style: TextStyle(fontSize: 12.3, color: Colors.red.shade500)
+              // 여행 날짜 선택 영역 - DateSelectSection 위젯 분리 적용
+              DateSelectSection(
+                width: width,
+                height: height,
+                viewModel: viewModel,
               ),
 
               SizedBox(height: height * 0.073,),

--- a/lib/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart
+++ b/lib/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:alpha_fe/providers/auth_provider.dart';
+import 'package:alpha_fe/pages/add_page/add_page_1/add_page_1.dart';
+import 'package:alpha_fe/pages/add_page/add_page_2/add_page_2.dart';
+import 'package:alpha_fe/components/custom_alert_dialog.dart';
+import 'package:alpha_fe/pages/add_page/add_page_0/view_model/tour_create_view_model.dart';
+
+class AddPage0ViewModel with ChangeNotifier {
+  final TextEditingController titleController = TextEditingController();
+  DateTimeRange? selectedDateRange;
+
+  bool validateInput(BuildContext context) {
+    final title = titleController.text.trim();
+    print('title: "$title", length: ${title.length}');
+    print('selectedDateRange: $selectedDateRange');
+
+    if (title.isEmpty || title.length > 10 || selectedDateRange == null) {
+      showDialog(
+        context: context,
+        builder: (context) => const CustomAlertDialog(
+          title: '입력 오류',
+          contentText: '여행 이름(10자 이내)과 날짜를 모두 입력해주세요',
+        ),
+      );
+      return false;
+    }
+    return true;
+  }
+
+  Future<void> selectDateRange(BuildContext context) async {
+    final DateTime now = DateTime.now();
+    final DateTimeRange? picked = await showDateRangePicker(
+      context: context,
+      locale: const Locale('ko', 'KR'),
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 365 * 5)),
+      builder: (context, child) {
+        return Theme(
+          data: ThemeData(
+            brightness: Brightness.light,
+            dialogTheme: const DialogTheme(
+              backgroundColor: Colors.white,
+            ),
+            colorScheme: const ColorScheme.light(
+              primary: Color(0xFF2C2C2C),
+              onPrimary: Colors.white,
+              onSurface: Colors.black,
+              secondary: Color(0xFFFFF176),
+            ),
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(
+                foregroundColor: const Color(0xFF2C2C2C),
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(8.0)),
+                ),
+              ),
+            ),
+          ),
+          child: child!,
+        );
+      },
+    );
+
+    if (picked != null) {
+      if (picked.duration.inDays > 2) {
+        await showDialog(
+          context: context,
+          builder: (context) => const CustomAlertDialog(
+            title: '안내',
+            contentText: '최대 3일까지 선택할 수 있습니다.',
+          ),
+        );
+        return;
+      }
+
+      selectedDateRange = picked;
+      notifyListeners();
+    }
+  }
+
+  void createTour(
+      BuildContext context,
+      String? sigun,
+      ) {
+    if (!validateInput(context)) return;
+
+    final title = titleController.text;
+    final dateRange = selectedDateRange!;
+    final accessToken = context.read<AuthProvider>().accessToken;
+
+    context.read<TourCreateViewModel>().registerTour(
+      context,
+      title,
+      dateRange,
+      onSuccess: (tourId) {
+        if (sigun != null) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => AddPage_2(
+                title: sigun,
+                tourId: tourId,
+                accessToken: accessToken,
+              ),
+            ),
+          );
+        } else {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => AddPage_1(
+                tourId: tourId,
+                accessToken: accessToken,
+              ),
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    titleController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart
+++ b/lib/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:alpha_fe/providers/auth_provider.dart';
 import 'package:alpha_fe/pages/add_page/add_page_1/add_page_1.dart';
 import 'package:alpha_fe/pages/add_page/add_page_2/add_page_2.dart';
 import 'package:alpha_fe/components/custom_alert_dialog.dart';
@@ -87,7 +86,6 @@ class AddPage0ViewModel with ChangeNotifier {
 
     final title = titleController.text;
     final dateRange = selectedDateRange!;
-    final accessToken = context.read<AuthProvider>().accessToken;
 
     context.read<TourCreateViewModel>().registerTour(
       context,
@@ -101,7 +99,6 @@ class AddPage0ViewModel with ChangeNotifier {
               builder: (context) => AddPage_2(
                 title: sigun,
                 tourId: tourId,
-                accessToken: accessToken,
               ),
             ),
           );
@@ -111,13 +108,18 @@ class AddPage0ViewModel with ChangeNotifier {
             MaterialPageRoute(
               builder: (context) => AddPage_1(
                 tourId: tourId,
-                accessToken: accessToken,
               ),
             ),
           );
         }
       },
     );
+  }
+
+  void resetState() {
+    titleController.clear();
+    selectedDateRange = null;
+    notifyListeners();
   }
 
   @override

--- a/lib/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart
+++ b/lib/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart
@@ -2,87 +2,31 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:alpha_fe/pages/add_page/add_page_1/add_page_1.dart';
 import 'package:alpha_fe/pages/add_page/add_page_2/add_page_2.dart';
-import 'package:alpha_fe/components/custom_alert_dialog.dart';
 import 'package:alpha_fe/pages/add_page/add_page_0/view_model/tour_create_view_model.dart';
 
 class AddPage0ViewModel with ChangeNotifier {
   final TextEditingController titleController = TextEditingController();
   DateTimeRange? selectedDateRange;
 
-  bool validateInput(BuildContext context) {
+  bool validateInputValuesOnly() {
     final title = titleController.text.trim();
-    print('title: "$title", length: ${title.length}');
-    print('selectedDateRange: $selectedDateRange');
-
-    if (title.isEmpty || title.length > 10 || selectedDateRange == null) {
-      showDialog(
-        context: context,
-        builder: (context) => const CustomAlertDialog(
-          title: '입력 오류',
-          contentText: '여행 이름(10자 이내)과 날짜를 모두 입력해주세요',
-        ),
-      );
-      return false;
-    }
-    return true;
+    return title.isNotEmpty && title.length <= 10 && selectedDateRange != null;
   }
 
-  Future<void> selectDateRange(BuildContext context) async {
-    final DateTime now = DateTime.now();
-    final DateTimeRange? picked = await showDateRangePicker(
-      context: context,
-      locale: const Locale('ko', 'KR'),
-      firstDate: now,
-      lastDate: now.add(const Duration(days: 365 * 5)),
-      builder: (context, child) {
-        return Theme(
-          data: ThemeData(
-            brightness: Brightness.light,
-            dialogTheme: const DialogTheme(
-              backgroundColor: Colors.white,
-            ),
-            colorScheme: const ColorScheme.light(
-              primary: Color(0xFF2C2C2C),
-              onPrimary: Colors.white,
-              onSurface: Colors.black,
-              secondary: Color(0xFFFFF176),
-            ),
-            textButtonTheme: TextButtonThemeData(
-              style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFF2C2C2C),
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(8.0)),
-                ),
-              ),
-            ),
-          ),
-          child: child!,
-        );
-      },
-    );
-
-    if (picked != null) {
-      if (picked.duration.inDays > 2) {
-        await showDialog(
-          context: context,
-          builder: (context) => const CustomAlertDialog(
-            title: '안내',
-            contentText: '최대 3일까지 선택할 수 있습니다.',
-          ),
-        );
-        return;
-      }
-
-      selectedDateRange = picked;
-      notifyListeners();
-    }
+  bool isValidDateRange(DateTimeRange range) {
+    return range.duration.inDays <= 2;
   }
 
-  void createTour(
-      BuildContext context,
-      String? sigun,
-      ) {
-    if (!validateInput(context)) return;
+  void updateSelectedDateRange(DateTimeRange range) {
+    selectedDateRange = range;
+    notifyListeners();
+  }
+
+  bool createTour({
+    required BuildContext context,
+    required String? sigun,
+  }) {
+    if (!validateInputValuesOnly()) return false;
 
     final title = titleController.text;
     final dateRange = selectedDateRange!;
@@ -114,6 +58,7 @@ class AddPage0ViewModel with ChangeNotifier {
         }
       },
     );
+    return true;
   }
 
   void resetState() {

--- a/lib/pages/add_page/add_page_0/widgets/date_select_section.dart
+++ b/lib/pages/add_page/add_page_0/widgets/date_select_section.dart
@@ -64,7 +64,43 @@ class DateSelectSection extends StatelessWidget {
             DateSelectButton(
               height: height * 0.058,
               width: width * 0.14,
-              onPressed: () => viewModel.selectDateRange(context),
+              onPressed: () async {
+                final picked = await showDateRangePicker(
+                  context: context,
+                  firstDate: DateTime.now(),
+                  lastDate: DateTime.now().add(const Duration(days: 365)),
+                  locale: const Locale('ko', 'KR'),
+                  builder: (context, child) {
+                    return Theme(
+                      data: ThemeData.light().copyWith(
+                        colorScheme: const ColorScheme.light(
+                          primary: Color(0xFF2C2C2C),
+                          onPrimary: Colors.white,
+                          surface: Colors.white,
+                          onSurface: Colors.black87,
+                        ),
+                        dialogBackgroundColor: Colors.white,
+                      ),
+                      child: child!,
+                    );
+                  },
+                );
+
+                if (picked != null) {
+                  if (!viewModel.isValidDateRange(picked)) {
+                    showDialog(
+                      context: context,
+                      builder: (context) => const AlertDialog(
+                        title: Text('입력 오류'),
+                        content: Text('지금은 3일 이내로만 선택할 수 있습니다'),
+                      ),
+                    );
+                    return;
+                  }
+
+                  viewModel.updateSelectedDateRange(picked);
+                }
+              },
             ),
           ],
         ),

--- a/lib/pages/add_page/add_page_0/widgets/date_select_section.dart
+++ b/lib/pages/add_page/add_page_0/widgets/date_select_section.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:alpha_fe/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart';
+
+
+class DateSelectSection extends StatelessWidget {
+  final double width;
+  final double height;
+  final AddPage0ViewModel viewModel;
+
+  const DateSelectSection({
+    super.key,
+    required this.width,
+    required this.height,
+    required this.viewModel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "✏️ 여행 날짜",
+          style: TextStyle(
+            fontSize: 20.5,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        SizedBox(height: height * 0.01),
+        Row(
+          children: [
+            Expanded(
+              child: SizedBox(
+                height: height * 0.06,
+                child: TextField(
+                  readOnly: true,
+                  cursorColor: const Color(0xFF2C2C2C),
+                  decoration: InputDecoration(
+                    isDense: true,
+                    hintText: viewModel.selectedDateRange == null
+                        ? ""
+                        : "${viewModel.selectedDateRange!.start.year}.${viewModel.selectedDateRange!.start.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.start.day.toString().padLeft(2, '0')} ~ "
+                        "${viewModel.selectedDateRange!.end.year}.${viewModel.selectedDateRange!.end.month.toString().padLeft(2, '0')}.${viewModel.selectedDateRange!.end.day.toString().padLeft(2, '0')}",
+                    hintStyle: const TextStyle(
+                      fontSize: 12.3,
+                      color: Colors.grey,
+                      fontWeight: FontWeight.w400,
+                    ),
+                    filled: true,
+                    fillColor: const Color(0xFFF5F5F5),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    counterText: "",
+                    contentPadding: EdgeInsets.symmetric(
+                      vertical: height * 0.02,
+                      horizontal: width * 0.03,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(width: width * 0.02),
+            DateSelectButton(
+              height: height * 0.058,
+              width: width * 0.14,
+              onPressed: () => viewModel.selectDateRange(context),
+            ),
+          ],
+        ),
+        SizedBox(height: height * 0.005),
+        Text(
+          "• 지금은 3일만 선택할 수 있습니다",
+          style: TextStyle(
+            fontSize: 12.3,
+            color: Colors.red.shade500,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+
+class DateSelectButton extends StatelessWidget {
+  final double width;
+  final double height;
+  final VoidCallback onPressed;
+
+  const DateSelectButton({
+    super.key,
+    required this.width,
+    required this.height,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      width: width,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF2C2C2C),
+          foregroundColor: Colors.white,
+          padding: EdgeInsets.zero,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+        child: const Text(
+          "🗓️",
+          style: TextStyle(
+            fontSize: 18.5,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/add_page/add_page_0/widgets/title_input_section.dart
+++ b/lib/pages/add_page/add_page_0/widgets/title_input_section.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:alpha_fe/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart';
+
+class TitleInputSection extends StatelessWidget {
+  final AddPage0ViewModel viewModel;
+  final double width;
+  final double height;
+
+  const TitleInputSection({
+    super.key,
+    required this.viewModel,
+    required this.width,
+    required this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "✏️ 여행 제목",
+          style: TextStyle(
+            fontSize: 20.5,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        SizedBox(height: height * 0.01),
+        SizedBox(
+          height: height * 0.06,
+          child: TextField(
+            controller: viewModel.titleController,
+            maxLength: 10,
+            decoration: InputDecoration(
+              isDense: true,
+              hintText: "예) 여름 방학 서울 여행",
+              hintStyle: const TextStyle(
+                fontSize: 14.3,
+                color: Colors.grey,
+                fontWeight: FontWeight.w400,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              counterText: "",
+              contentPadding: EdgeInsets.symmetric(
+                vertical: height * 0.02,
+                horizontal: width * 0.03,
+              ),
+            ),
+          ),
+        ),
+        SizedBox(height: height * 0.005),
+        const Text(
+          "• 한글, 영문, 특수기호 구분없이 10자 이내로 입력",
+          style: TextStyle(fontSize: 12.3, color: Colors.grey),
+        ),
+        const Text(
+          "• 결정 후 수정할 수 없으니 신중히 정해주세요",
+          style: TextStyle(fontSize: 12.3, color: Colors.grey),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/add_page/add_page_1/add_page_1.dart
+++ b/lib/pages/add_page/add_page_1/add_page_1.dart
@@ -11,11 +11,11 @@ const List<String> districts = [
 ];
 
 class AddPage_1 extends StatelessWidget {
-  final String? accessToken;
   final int tourId;
+
   const AddPage_1({
     required this.tourId,
-    Key? key, required this.accessToken
+    Key? key,
   }) : super(key: key);
 
 
@@ -62,7 +62,7 @@ class AddPage_1 extends StatelessWidget {
               SizedBox(height: height * 0.0692),
 
               // 행정구역 목록에 있는 요소들에 대해 GeneratorItem 생성
-              ...districts.map((name) => GeneratorItem(title: name, tourId: tourId, accessToken: accessToken,)).toList(),
+              ...districts.map((name) => GeneratorItem(title: name, tourId: tourId, )).toList(),
             ],
           ),
         ),

--- a/lib/pages/add_page/add_page_2/add_page_2.dart
+++ b/lib/pages/add_page/add_page_2/add_page_2.dart
@@ -1,4 +1,5 @@
 import 'package:alpha_fe/pages/add_page/add_page_2/view_models/show_tour_course_view_model.dart';
+import 'package:alpha_fe/pages/add_page/add_page_2/view_models/add_page_2_view_model.dart';
 import 'package:alpha_fe/services/http/save_tour_course/save_tour_course_from_add.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -12,16 +13,16 @@ import '../../../components/placeinput_card.dart';
 import '../../../components/ai_loading_page.dart';
 import '../../../components/date_dropdown.dart';
 import '../../../components/custom_alert_dialog.dart';
+import 'package:alpha_fe/pages/add_page/add_page_2/models/place_info.dart';
 
 class AddPage_2 extends StatefulWidget {
-  final String? accessToken;
   final String title;
   final int tourId;
 
   const AddPage_2({
     required this.title,
     required this.tourId,
-    Key? key, required this.accessToken
+    Key? key,
   }) : super(key: key);
 
   @override
@@ -30,19 +31,7 @@ class AddPage_2 extends StatefulWidget {
 
 class _AddPage_2State extends State<AddPage_2> {
   late ScrollController _scrollController;
-  bool _visibleButton = true;
-  Timer? _idleTimer;
-
-  // 편집 모드 토글 상태를 저장 (true: 삭제 버튼 표시)
-  bool _isEditMode = false; // 편집 모드 여부
-
-  // 날짜별로 그룹화된 장소 데이터 목록 (날짜: 장소 리스트 쌍)
-  List<MapEntry<String, List<PlaceInfoBlock>>> _placeWidgets = [];
-
-  // 날짜별로 장소 추가 입력폼이 열려있는지 여부를 관리하는 맵
-  Map<String, bool> _isAddingPlaceMap = {};
-
-  String? _selectedDate;
+  bool _didReset = false;
 
   @override
   void initState() {
@@ -59,105 +48,6 @@ class _AddPage_2State extends State<AddPage_2> {
     });
   }
 
-  // 스크롤 상태에 따라 '이 코스로 할게요!' 버튼의 애니메이션을 제어
-  void myScrollNotification(ScrollNotification notification) {
-    if (notification is UserScrollNotification) {
-      final direction = notification.direction;
-      if (direction == ScrollDirection.idle) {
-        _idleTimer ??= Timer(const Duration(milliseconds: 750), () {
-          showFloatButton();
-        });
-      } else {
-        _idleTimer?.cancel();
-        _idleTimer = null;
-        if (_visibleButton) hideFloatButton();
-      }
-    }
-  }
-
-  void showFloatButton() {
-    if (!_visibleButton) {
-      setState(() {
-        _visibleButton = true;
-      });
-    }
-  }
-
-  void hideFloatButton() {
-    if (_visibleButton) {
-      setState(() {
-        _visibleButton = false;
-      });
-    }
-  }
-
-  // 사용자가 새 장소를 추가 완료하면 해당 날짜 그룹에 PlaceInfoBlock을 추가하고 입력폼 닫기
-  void addNewPlace(String date, String imageUrl, String title, String description, double mapX, double mapY) {
-
-    final entryIndex = _placeWidgets.indexWhere((entry) => entry.key == date);
-    final existingList = entryIndex != -1 ? _placeWidgets[entryIndex].value : [];
-
-    // 동일한 날짜 그룹 내에 이미 같은 정보의 장소가 있는지 확인 (좌표 근접 + 텍스트 유사)
-    final isDuplicate = existingList.any((place) {
-      // 정확한 장소명 비교
-      if (place.title == title) {
-        return true;
-      }
-
-      // 괄호 제거 함수
-      String stripParentheses(String input) {
-        return input.replaceAll(RegExp(r'\s*\([^)]*\)'), '');
-      }
-
-      // 기존 및 새 주소에서 괄호 포함된 부분 제거
-      final strippedExistingAddress = stripParentheses(place.description);
-      final strippedNewAddress = stripParentheses(description);
-
-      // 주소가 같을 경우 공백 제거 후 비교
-      if (strippedExistingAddress == strippedNewAddress) {
-        final normalize = (String s) => s.replaceAll(RegExp(r'\s+'), '');
-        if (normalize(strippedExistingAddress) == normalize(strippedNewAddress)) {
-          return true;
-        }
-      }
-
-      return false;
-    });
-    if (isDuplicate) {
-      // 중복될 경우 안내 다이얼로그 표시 후 추가 중단
-      showDialog(
-        context: context,
-        builder: (context) => const CustomAlertDialog(
-          title: '안내',
-          contentText: '이미 추가된 장소입니다',
-        ),
-      );
-      return;
-    }
-
-    setState(() {
-      double width = MediaQuery.of(context).size.width;
-      if (kIsWeb) {
-        width = 430;
-      }
-      final height = MediaQuery.of(context).size.height;
-      final newPlace = PlaceInfoBlock(
-        imageUrl: imageUrl,
-        title: title,
-        description: description,
-        mapX: mapX,
-        mapY: mapY,
-        width: width * 0.63,
-        height: height * 0.2//width* 0.63* 0.69,
-      );
-      if (entryIndex != -1) {
-        _placeWidgets[entryIndex].value.add(newPlace);
-      } else {
-        _placeWidgets.add(MapEntry(date, [newPlace]));
-      }
-      _isAddingPlaceMap[date] = false;
-    });
-  }
 
 
   // PlaceInfoBlock 목록 상단에 표시되는 안내 문구
@@ -193,230 +83,219 @@ class _AddPage_2State extends State<AddPage_2> {
     );
   }
 
-  // 날짜별 섹션 제목을 그리는 위젯
-  Widget _buildDateDropdown() {
-    double width = MediaQuery.of(context).size.width;
-    if (kIsWeb) {
-      width = 430;
-    }
-
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: width * 0.05),
-      child: DropdownButton<String>(
-        value: _selectedDate,
-        isExpanded: true,
-        dropdownColor: const Color(0xFFF5F5F5),
-        hint: const Text("날짜를 선택해주세요", style: TextStyle(fontSize: 18.5, color: Colors.black)),
-        items: _placeWidgets.map((entry) {
-          return DropdownMenuItem<String>(
-            value: entry.key,
-            child: Text(entry.key, style: const TextStyle(fontSize: 20.5, fontWeight: FontWeight.bold)),
-          );
-        }).toList(),
-        onChanged: (value) {
-          setState(() {
-            _selectedDate = value;
-          });
-        },
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
-    final height = MediaQuery.of(context).size.height;
-    double width = MediaQuery.of(context).size.width;
-    final viewModel = context.watch<ShowTourCourseViewModel>();
-    final placeWidgets = viewModel.placeMap.entries.toList();
-    if (kIsWeb) {
-      width = 430;
-    }
-    if (viewModel.isLoading) {
-      return const AILoadingView();
-    }
-    return Scaffold(
-      backgroundColor: const Color(0xFFFFFFFF),
-      appBar: const DefaultAppBar(title: "새 여행지 추가"),
-      body: Stack(
-        alignment: Alignment.center,
-        children: [
+    return ChangeNotifierProvider<AddPage2ViewModel>(
+      create: (_) => AddPage2ViewModel(),
+      builder: (context, _) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          context.read<AddPage2ViewModel>().onViewEnter();
+        });
+        final height = MediaQuery.of(context).size.height;
+        double width = MediaQuery.of(context).size.width;
+        final viewModel = context.watch<ShowTourCourseViewModel>();
+        final addPage2ViewModel = context.watch<AddPage2ViewModel>();
 
-          // 스크롤 리스너를 통해 버튼의 애니메이션 상태를 제어
-          NotificationListener<ScrollNotification>(
-            onNotification: (notification) {
-              myScrollNotification(notification);
-              return false;
-            },
-            child: SingleChildScrollView(
-              controller: _scrollController,
-              child: Padding(
-                padding: EdgeInsets.symmetric(
-                  vertical: height * 0.0138,
-                  horizontal: width * 0.06,
-                ),
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(
-                    minHeight: height,
-                    minWidth: width,
-                  ),
+        if (addPage2ViewModel.placeInfos.isEmpty && viewModel.placeMap.isNotEmpty) {
+          addPage2ViewModel.placeInfos.addEntries(
+            viewModel.placeMap.entries.map((e) =>
+              MapEntry<String, List<PlaceInfo>>(e.key, List<PlaceInfo>.from(e.value))
+            ),
+          );
+          if (addPage2ViewModel.selectedDate.value == null) {
+            addPage2ViewModel.selectedDate.value = viewModel.placeMap.keys.first;
+          }
+        }
 
-                  // 장소 정보 블록들을 나열하는 최상위 Column
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      SizedBox(height: height * 0.028),
-                      _buildTitleBlock(),
-                      SizedBox(height: height * 0.0267),
-                      DateDropdown(
-                        selectedDate: ValueNotifier<String?>(_selectedDate),
-                        dates: placeWidgets.map((e) => e.key).toList(),
-                        height: height,
-                        width: width,
-                        onChanged: (value) {
-                          setState(() {
-                            _selectedDate = value;
-                          });
-                        },
+        if (kIsWeb) {
+          width = 430;
+        }
+        if (viewModel.isLoading) {
+          return const AILoadingView();
+        }
+        return Scaffold(
+          backgroundColor: const Color(0xFFFFFFFF),
+          appBar: const DefaultAppBar(title: "새 여행지 추가"),
+          body: Stack(
+            alignment: Alignment.center,
+            children: [
+              NotificationListener<ScrollNotification>(
+                onNotification: (notification) {
+                  addPage2ViewModel.handleScrollNotification(notification);
+                  return false;
+                },
+                child: SingleChildScrollView(
+                  controller: _scrollController,
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(
+                      vertical: height * 0.0138,
+                      horizontal: width * 0.06,
+                    ),
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: height,
+                        minWidth: width,
                       ),
-
-
-                      // 장소 목록 표시 - 그룹화된 날짜별 렌더링
-                      if (placeWidgets.isNotEmpty && placeWidgets[0].value.isNotEmpty)
-                        // 편집모드 토글 버튼
-                        // 연필 아이콘: 편집 모드로 진입하여 각 장소에 삭제(X) 버튼 노출
-                        // 저장 아이콘: 편집 모드 종료 및 삭제 버튼 숨김
-                        Align(
-                          alignment: Alignment.centerRight,
-                          child: IconButton(
-                            icon: Icon(
-                              _isEditMode ? Icons.save : Icons.edit,
-                              color: Colors.black87,
-                            ),
-                            onPressed: () {
-                              setState(() {
-                                _isEditMode = !_isEditMode;
-                              });
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          SizedBox(height: height * 0.028),
+                          _buildTitleBlock(),
+                          SizedBox(height: height * 0.0267),
+                          DateDropdown(
+                            selectedDate: addPage2ViewModel.selectedDate,
+                            dates: addPage2ViewModel.placeInfos.keys.toList(),
+                            height: height,
+                            width: width,
+                            onChanged: (value) {
+                              addPage2ViewModel.updateSelectedDate(value);
                             },
                           ),
-                        ),
-                      for (var entry in placeWidgets.where((e) => e.key == _selectedDate)) ...[
-                        SizedBox.shrink(),
-                        for (var place in entry.value) ...[
-                          Stack(
-                            children: [
-                              PlaceInfoBlock(
-                                imageUrl: place.imageUrl,
-                                title: place.title,
-                                description: place.description,
-                                mapX: place.mapX,
-                                mapY: place.mapY,
-                                width: width * 0.63,
-                                height: height * 0.2,
-                              ),
-                              if (_isEditMode)
-                                Positioned(
-                                  top: 0,
-                                  left: 0,
-                                  child: GestureDetector(
-                                    onTap: () {
-                                      setState(() {
-                                        entry.value.remove(place);
-                                      });
-                                    },
-                                    child: Container(
-                                      decoration: BoxDecoration(
-                                        color: Colors.red.withOpacity(0.8),
-                                        shape: BoxShape.circle,
-                                      ),
-                                      padding: EdgeInsets.symmetric(
-                                        vertical: height * .004,
-                                        horizontal: width * 0.01,
-                                      ),
-                                      child: const Icon(Icons.close, size: 18.5, color: Colors.white),
-                                    ),
-                                  ),
+                          if (addPage2ViewModel.placeInfos.isNotEmpty &&
+                              addPage2ViewModel.placeInfos.entries.any((e) => e.value.isNotEmpty))
+                            Align(
+                              alignment: Alignment.centerRight,
+                              child: IconButton(
+                                icon: Icon(
+                                  addPage2ViewModel.isEditMode ? Icons.save : Icons.edit,
+                                  color: Colors.black87,
                                 ),
-                            ],
-                          ),
-                          SizedBox(height: height * 0.0268),
-                        ],
-                        // 날짜별로 추가된 코스 아래에 위치하는 '+ 장소 추가' 버튼
-                        // 버튼을 누르면 해당 날짜에 새로운 장소 입력폼(PlaceInputCard) 표시됨
-                        // 사용자가 입력을 완료하면 해당 날짜 섹션에만 장소가 추가됨
-                        (_isAddingPlaceMap[entry.key] == true && !kIsWeb)
-                            ? PlaceInputCard(
-                                onComplete: (imageUrl, title, description, mapX, mapY) =>
-                                    addNewPlace(entry.key, imageUrl, title, description, mapX, mapY),
-                                onCancel: () => setState(() => _isAddingPlaceMap[entry.key] = false),
-                              )
-                            : (!kIsWeb
-                                ? GestureDetector(
-                                    onTap: () => setState(() => _isAddingPlaceMap[entry.key] = true),
-                                    child: Container(
-                                      width: width * 0.63,
-                                      height: height * 0.2,
-                                      decoration: BoxDecoration(
-                                        border: Border.all(color: Colors.grey.shade400),
-                                        borderRadius: BorderRadius.circular(12),
-                                      ),
-                                      child: const Center(
-                                        child: Text(
-                                          '+ 장소 추가',
-                                          style: TextStyle(fontSize: 16.5),
+                                onPressed: () {
+                                  addPage2ViewModel.toggleEditMode();
+                                },
+                              ),
+                            ),
+                          if (addPage2ViewModel.selectedDate.value != null)
+                            for (var info in addPage2ViewModel.placeInfos[addPage2ViewModel.selectedDate.value!] ?? []) ...[
+                              Stack(
+                                children: [
+                                  PlaceInfoBlock(
+                                    imageUrl: info.imageUrl,
+                                    title: info.title,
+                                    description: info.description,
+                                    mapX: info.mapX,
+                                    mapY: info.mapY,
+                                    width: width * 0.63,
+                                    height: height * 0.2,
+                                  ),
+                                  if (addPage2ViewModel.isEditMode)
+                                    Positioned(
+                                      top: 0,
+                                      left: 0,
+                                      child: GestureDetector(
+                                        onTap: () {
+                                          addPage2ViewModel.removePlace(addPage2ViewModel.selectedDate.value!, info);
+                                        },
+                                        child: Container(
+                                          decoration: BoxDecoration(
+                                            color: Colors.red.withOpacity(0.8),
+                                            shape: BoxShape.circle,
+                                          ),
+                                          padding: EdgeInsets.symmetric(
+                                            vertical: height * .004,
+                                            horizontal: width * 0.01,
+                                          ),
+                                          child: const Icon(Icons.close, size: 18.5, color: Colors.white),
                                         ),
                                       ),
                                     ),
+                                ],
+                              ),
+                              SizedBox(height: height * 0.0268),
+                            ],
+                          if (addPage2ViewModel.selectedDate.value != null)
+                            (addPage2ViewModel.isAddingPlaceMap[addPage2ViewModel.selectedDate.value!] == true && !kIsWeb)
+                                ? PlaceInputCard(
+                                    onComplete: (imageUrl, title, description, mapX, mapY) {
+                                      if (addPage2ViewModel.isDuplicatePlace(addPage2ViewModel.selectedDate.value!, title, description)) {
+                                        showDialog(
+                                          context: context,
+                                          builder: (context) => const CustomAlertDialog(
+                                            title: '안내',
+                                            contentText: '이미 추가된 장소입니다',
+                                          ),
+                                        );
+                                        return;
+                                      }
+                                      final newPlace = PlaceInfo(
+                                        imageUrl: imageUrl,
+                                        title: title,
+                                        description: description,
+                                        mapX: mapX,
+                                        mapY: mapY,
+                                      );
+                                      addPage2ViewModel.addNewPlace(addPage2ViewModel.selectedDate.value!, newPlace);
+                                    },
+                                    onCancel: () => addPage2ViewModel.toggleAddingPlace(addPage2ViewModel.selectedDate.value!, false),
                                   )
-                                : const SizedBox.shrink()),
-                        SizedBox(height: height * 0.0184),
-                      ],
-                      SizedBox(height: height * 0.13),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ),
-
-          // '이 코스로 할게요!' 버튼, 고정 위치에 애니메이션 효과 적용
-          Visibility(
-            visible: _visibleButton,
-            maintainSize: false,
-            maintainAnimation: true,
-            maintainState: true,
-            child: Stack(
-              children: [
-                Positioned(
-                  bottom: height * 0.0344,
-                  left: 0,
-                  right: 0,
-                  child: AnimatedSlide(
-                    duration: const Duration(milliseconds: 300),
-                    offset: _visibleButton ? Offset.zero : const Offset(0, 1.2),
-                    curve: Curves.easeInOut,
-                    child: Center(
-                      child: ProceedButton(
-                        size_w: width * 0.53,
-                        size_h: height * 0.055,
-                        text: "이 코스로 할게요!",
-                        fontSize_: 14.3,
-                        fontWeight_: FontWeight.bold,
-                        onTap: () async {
-                            await SaveTourCourseFromAdd().saveCourse(
-                              context: context,
-                              placeWidgets: _placeWidgets,
-                              tourId: widget.tourId,
-                            );
-                        },
+                                : (!kIsWeb
+                                    ? GestureDetector(
+                                        onTap: () => addPage2ViewModel.toggleAddingPlace(addPage2ViewModel.selectedDate.value!, true),
+                                        child: Container(
+                                          width: width * 0.63,
+                                          height: height * 0.2,
+                                          decoration: BoxDecoration(
+                                            border: Border.all(color: Colors.grey.shade400),
+                                            borderRadius: BorderRadius.circular(12),
+                                          ),
+                                          child: const Center(
+                                            child: Text(
+                                              '+ 장소 추가',
+                                              style: TextStyle(fontSize: 16.5),
+                                            ),
+                                          ),
+                                        ),
+                                      )
+                                    : const SizedBox.shrink()),
+                          SizedBox(height: height * 0.0184),
+                          SizedBox(height: height * 0.13),
+                        ],
                       ),
                     ),
                   ),
                 ),
-              ],
-            ),
-          )
-        ],
-      ),
+              ),
+              Visibility(
+                visible: addPage2ViewModel.visibleButton,
+                maintainSize: false,
+                maintainAnimation: true,
+                maintainState: true,
+                child: Stack(
+                  children: [
+                    Positioned(
+                      bottom: height * 0.0344,
+                      left: 0,
+                      right: 0,
+                      child: AnimatedSlide(
+                        duration: const Duration(milliseconds: 300),
+                        offset: addPage2ViewModel.visibleButton ? Offset.zero : const Offset(0, 1.2),
+                        curve: Curves.easeInOut,
+                        child: Center(
+                          child: ProceedButton(
+                            size_w: width * 0.53,
+                            size_h: height * 0.055,
+                            text: "이 코스로 할게요!",
+                            fontSize_: 14.3,
+                            fontWeight_: FontWeight.bold,
+                            onTap: () async {
+                              await SaveTourCourseFromAdd().saveCourse(
+                                context: context,
+                                placeWidgets: addPage2ViewModel.placeInfos.entries.toList(),
+                                tourId: widget.tourId,
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/pages/add_page/add_page_2/add_page_2.dart
+++ b/lib/pages/add_page/add_page_2/add_page_2.dart
@@ -8,12 +8,12 @@ import 'package:provider/provider.dart';
 import 'dart:async';
 import '../../../components/app_bar.dart';
 import '../../../components/proceed_button.dart';
-import '../../../components/placeinfo_card.dart';
-import '../../../components/placeinput_card.dart';
 import '../../../components/ai_loading_page.dart';
-import '../../../components/date_dropdown.dart';
-import '../../../components/custom_alert_dialog.dart';
 import 'package:alpha_fe/pages/add_page/add_page_2/models/place_info.dart';
+import 'widgets/title_block.dart';
+import 'widgets/date_selector.dart';
+import 'widgets/place_info_list_section.dart';
+import 'widgets/place_input_area.dart';
 
 class AddPage_2 extends StatefulWidget {
   final String title;
@@ -31,7 +31,6 @@ class AddPage_2 extends StatefulWidget {
 
 class _AddPage_2State extends State<AddPage_2> {
   late ScrollController _scrollController;
-  bool _didReset = false;
 
   @override
   void initState() {
@@ -48,40 +47,6 @@ class _AddPage_2State extends State<AddPage_2> {
     });
   }
 
-
-
-  // PlaceInfoBlock 목록 상단에 표시되는 안내 문구
-  Widget _buildTitleBlock() {
-    double width = MediaQuery.of(context).size.width;
-    final height = MediaQuery.of(context).size.height;
-    if (kIsWeb) {
-      width = 430;
-    }
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text("📍${widget.title}", style: const TextStyle(fontSize: 26.7, fontWeight: FontWeight.w900)),
-        const Padding(
-          padding: EdgeInsets.only(left: 37.5),
-          child: Text('근처 코스를 알려드릴게요', style: TextStyle(fontSize: 14.3, color: Color(0xFF757575))),
-        ),
-        SizedBox(height: height * 0.0138),
-        Padding(
-          padding: EdgeInsets.symmetric(horizontal: width * 0.02),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
-            children: [
-              const Text('최근 업데이트: ', style: TextStyle(fontSize: 14.3, fontWeight: FontWeight.bold, color: Color(0xFF7F7F7F))),
-              SizedBox(width: width * 0.01),
-              // 오늘 날짜를 yyyy-MM-dd 형식으로 표시
-              Text(DateTime.now().toLocal().toString().substring(0, 10), style: TextStyle(fontSize: width * 0.03, color: const Color(0xFF7F7F7F))),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
 
 
   @override
@@ -141,11 +106,11 @@ class _AddPage_2State extends State<AddPage_2> {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           SizedBox(height: height * 0.028),
-                          _buildTitleBlock(),
+                          TitleBlock(title: widget.title),
                           SizedBox(height: height * 0.0267),
-                          DateDropdown(
-                            selectedDate: addPage2ViewModel.selectedDate,
+                          DateSelector(
                             dates: addPage2ViewModel.placeInfos.keys.toList(),
+                            selectedDate: addPage2ViewModel.selectedDate,
                             height: height,
                             width: width,
                             onChanged: (value) {
@@ -167,87 +132,29 @@ class _AddPage_2State extends State<AddPage_2> {
                               ),
                             ),
                           if (addPage2ViewModel.selectedDate.value != null)
-                            for (var info in addPage2ViewModel.placeInfos[addPage2ViewModel.selectedDate.value!] ?? []) ...[
-                              Stack(
-                                children: [
-                                  PlaceInfoBlock(
-                                    imageUrl: info.imageUrl,
-                                    title: info.title,
-                                    description: info.description,
-                                    mapX: info.mapX,
-                                    mapY: info.mapY,
-                                    width: width * 0.63,
-                                    height: height * 0.2,
-                                  ),
-                                  if (addPage2ViewModel.isEditMode)
-                                    Positioned(
-                                      top: 0,
-                                      left: 0,
-                                      child: GestureDetector(
-                                        onTap: () {
-                                          addPage2ViewModel.removePlace(addPage2ViewModel.selectedDate.value!, info);
-                                        },
-                                        child: Container(
-                                          decoration: BoxDecoration(
-                                            color: Colors.red.withOpacity(0.8),
-                                            shape: BoxShape.circle,
-                                          ),
-                                          padding: EdgeInsets.symmetric(
-                                            vertical: height * .004,
-                                            horizontal: width * 0.01,
-                                          ),
-                                          child: const Icon(Icons.close, size: 18.5, color: Colors.white),
-                                        ),
-                                      ),
-                                    ),
-                                ],
-                              ),
-                              SizedBox(height: height * 0.0268),
-                            ],
+                            PlaceInfoListSection(
+                              placeList: addPage2ViewModel.placeInfos[addPage2ViewModel.selectedDate.value!] ?? [],
+                              isEditMode: addPage2ViewModel.isEditMode,
+                              width: width,
+                              height: height,
+                              onRemove: (info) {
+                                addPage2ViewModel.removePlace(addPage2ViewModel.selectedDate.value!, info);
+                              },
+                            ),
                           if (addPage2ViewModel.selectedDate.value != null)
-                            (addPage2ViewModel.isAddingPlaceMap[addPage2ViewModel.selectedDate.value!] == true && !kIsWeb)
-                                ? PlaceInputCard(
-                                    onComplete: (imageUrl, title, description, mapX, mapY) {
-                                      if (addPage2ViewModel.isDuplicatePlace(addPage2ViewModel.selectedDate.value!, title, description)) {
-                                        showDialog(
-                                          context: context,
-                                          builder: (context) => const CustomAlertDialog(
-                                            title: '안내',
-                                            contentText: '이미 추가된 장소입니다',
-                                          ),
-                                        );
-                                        return;
-                                      }
-                                      final newPlace = PlaceInfo(
-                                        imageUrl: imageUrl,
-                                        title: title,
-                                        description: description,
-                                        mapX: mapX,
-                                        mapY: mapY,
-                                      );
-                                      addPage2ViewModel.addNewPlace(addPage2ViewModel.selectedDate.value!, newPlace);
-                                    },
-                                    onCancel: () => addPage2ViewModel.toggleAddingPlace(addPage2ViewModel.selectedDate.value!, false),
-                                  )
-                                : (!kIsWeb
-                                    ? GestureDetector(
-                                        onTap: () => addPage2ViewModel.toggleAddingPlace(addPage2ViewModel.selectedDate.value!, true),
-                                        child: Container(
-                                          width: width * 0.63,
-                                          height: height * 0.2,
-                                          decoration: BoxDecoration(
-                                            border: Border.all(color: Colors.grey.shade400),
-                                            borderRadius: BorderRadius.circular(12),
-                                          ),
-                                          child: const Center(
-                                            child: Text(
-                                              '+ 장소 추가',
-                                              style: TextStyle(fontSize: 16.5),
-                                            ),
-                                          ),
-                                        ),
-                                      )
-                                    : const SizedBox.shrink()),
+                            PlaceInputArea(
+                              isAdding: addPage2ViewModel.isAddingPlaceMap[addPage2ViewModel.selectedDate.value!] == true,
+                              isWeb: kIsWeb,
+                              width: width,
+                              height: height,
+                              onTapAdd: () => addPage2ViewModel.toggleAddingPlace(addPage2ViewModel.selectedDate.value!, true),
+                              onCancel: () => addPage2ViewModel.toggleAddingPlace(addPage2ViewModel.selectedDate.value!, false),
+                              onComplete: (info) {
+                                addPage2ViewModel.addNewPlace(addPage2ViewModel.selectedDate.value!, info);
+                              },
+                              isDuplicate: (title, desc) =>
+                                addPage2ViewModel.isDuplicatePlace(addPage2ViewModel.selectedDate.value!, title, desc),
+                            ),
                           SizedBox(height: height * 0.0184),
                           SizedBox(height: height * 0.13),
                         ],

--- a/lib/pages/add_page/add_page_2/view_models/add_page_2_view_model.dart
+++ b/lib/pages/add_page/add_page_2/view_models/add_page_2_view_model.dart
@@ -14,7 +14,10 @@ class AddPage2ViewModel extends ChangeNotifier {
   bool _hasInitialized = false;
 
   void onViewEnter() {
-    resetState();
+    if (!_hasInitialized) {
+      resetState();
+      _hasInitialized = true;
+    }
   }
 
   void toggleEditMode() {
@@ -117,6 +120,7 @@ class AddPage2ViewModel extends ChangeNotifier {
     _visibleButton = true;
     _idleTimer?.cancel();
     _idleTimer = null;
+    _hasInitialized = false;
     notifyListeners();
   }
 

--- a/lib/pages/add_page/add_page_2/view_models/add_page_2_view_model.dart
+++ b/lib/pages/add_page/add_page_2/view_models/add_page_2_view_model.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:alpha_fe/pages/add_page/add_page_2/models/place_info.dart';
+import 'dart:async';
+
+class AddPage2ViewModel extends ChangeNotifier {
+  bool isEditMode = false;
+  ValueNotifier<String?> selectedDate = ValueNotifier(null);
+
+  final Map<String, bool> isAddingPlaceMap = {};
+  final Map<String, List<PlaceInfo>> placeInfos = {};
+
+  bool _hasInitialized = false;
+
+  void onViewEnter() {
+    resetState();
+  }
+
+  void toggleEditMode() {
+    isEditMode = !isEditMode;
+    notifyListeners();
+  }
+
+  void updateSelectedDate(String? date) {
+    selectedDate.value = date;
+    notifyListeners();
+  }
+
+  void toggleAddingPlace(String date, bool isAdding) {
+    isAddingPlaceMap[date] = isAdding;
+    notifyListeners();
+  }
+
+  void addNewPlace(String date, PlaceInfo newPlace) {
+    if (placeInfos.containsKey(date)) {
+      placeInfos[date]!.add(newPlace);
+    } else {
+      placeInfos[date] = [newPlace];
+    }
+
+    isAddingPlaceMap[date] = false;
+    notifyListeners();
+  }
+
+  void removePlace(String date, PlaceInfo place) {
+    if (placeInfos.containsKey(date)) {
+      placeInfos[date]!.remove(place);
+      notifyListeners();
+    }
+  }
+
+  bool isDuplicatePlace(String date, String title, String address) {
+    if (!placeInfos.containsKey(date)) return false;
+
+    final existingList = placeInfos[date]!;
+
+    // 장소명 중복 검사
+    final titleMatch = existingList.any((place) => place.title == title);
+    if (titleMatch) return true;
+
+    // 주소 유사도 검사: 괄호 제거 후 공백 제거 비교
+    String normalize(String s) {
+      return s.replaceAll(RegExp(r'\s*\([^)]*\)'), '').replaceAll(RegExp(r'\s+'), '');
+    }
+
+    final normalizedNewAddress = normalize(address);
+
+    for (final place in existingList) {
+      if (normalize(place.description) == normalizedNewAddress) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool get visibleButton => _visibleButton;
+
+  void handleScrollNotification(ScrollNotification notification) {
+    if (notification is UserScrollNotification) {
+      final direction = notification.direction;
+      if (direction == ScrollDirection.idle) {
+        _idleTimer ??= Timer(const Duration(milliseconds: 750), () {
+          showFloatButton();
+        });
+      } else {
+        _idleTimer?.cancel();
+        _idleTimer = null;
+        if (_visibleButton) hideFloatButton();
+      }
+    }
+  }
+
+  void showFloatButton() {
+    if (!_visibleButton) {
+      _visibleButton = true;
+      notifyListeners();
+    }
+  }
+
+  void hideFloatButton() {
+    if (_visibleButton) {
+      _visibleButton = false;
+      notifyListeners();
+    }
+  }
+
+  bool _visibleButton = true;
+  Timer? _idleTimer;
+
+  void resetState() {
+    isEditMode = false;
+    selectedDate.value = null;
+    isAddingPlaceMap.clear();
+    placeInfos.clear();
+    _visibleButton = true;
+    _idleTimer?.cancel();
+    _idleTimer = null;
+    notifyListeners();
+  }
+
+
+}

--- a/lib/pages/add_page/add_page_2/widgets/date_selector.dart
+++ b/lib/pages/add_page/add_page_2/widgets/date_selector.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import '../../../../components/date_dropdown.dart';
+
+class DateSelector extends StatelessWidget {
+  final List<String> dates;
+  final ValueNotifier<String?> selectedDate;
+  final double height;
+  final double width;
+  final void Function(String?) onChanged;
+
+  const DateSelector({
+    required this.dates,
+    required this.selectedDate,
+    required this.height,
+    required this.width,
+    required this.onChanged,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return DateDropdown(
+      selectedDate: selectedDate,
+      dates: dates,
+      height: height,
+      width: width,
+      onChanged: onChanged,
+    );
+  }
+}

--- a/lib/pages/add_page/add_page_2/widgets/place_info_list_section.dart
+++ b/lib/pages/add_page/add_page_2/widgets/place_info_list_section.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:alpha_fe/pages/add_page/add_page_2/models/place_info.dart';
+import '../../../../components/placeinfo_card.dart';
+
+class PlaceInfoListSection extends StatelessWidget {
+  final List<PlaceInfo> placeList;
+  final bool isEditMode;
+  final double width;
+  final double height;
+  final void Function(PlaceInfo) onRemove;
+
+  const PlaceInfoListSection({
+    required this.placeList,
+    required this.isEditMode,
+    required this.width,
+    required this.height,
+    required this.onRemove,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: placeList.map((info) {
+        return Column(
+          children: [
+            Stack(
+              children: [
+                PlaceInfoBlock(
+                  imageUrl: info.imageUrl,
+                  title: info.title,
+                  description: info.description,
+                  mapX: info.mapX,
+                  mapY: info.mapY,
+                  width: width * 0.63,
+                  height: height * 0.2,
+                ),
+                if (isEditMode)
+                  Positioned(
+                    top: 0,
+                    left: 0,
+                    child: GestureDetector(
+                      onTap: () => onRemove(info),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: Colors.red.withOpacity(0.8),
+                          shape: BoxShape.circle,
+                        ),
+                        padding: EdgeInsets.symmetric(
+                          vertical: height * 0.004,
+                          horizontal: width * 0.01,
+                        ),
+                        child: const Icon(Icons.close, size: 18.5, color: Colors.white),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            SizedBox(height: height * 0.0268),
+          ],
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/pages/add_page/add_page_2/widgets/place_input_area.dart
+++ b/lib/pages/add_page/add_page_2/widgets/place_input_area.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../../../../components/placeinput_card.dart';
+import 'package:alpha_fe/pages/add_page/add_page_2/models/place_info.dart';
+
+class PlaceInputArea extends StatelessWidget {
+  final bool isAdding;
+  final bool isWeb;
+  final double width;
+  final double height;
+  final void Function() onTapAdd;
+  final void Function() onCancel;
+  final void Function(PlaceInfo) onComplete;
+  final bool Function(String title, String description) isDuplicate;
+
+  const PlaceInputArea({
+    required this.isAdding,
+    required this.isWeb,
+    required this.width,
+    required this.height,
+    required this.onTapAdd,
+    required this.onCancel,
+    required this.onComplete,
+    required this.isDuplicate,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (isAdding && !isWeb) {
+      return PlaceInputCard(
+        onComplete: (imageUrl, title, description, mapX, mapY) {
+          if (isDuplicate(title, description)) {
+            showDialog(
+              context: context,
+              builder: (context) => const AlertDialog(
+                title: Text('안내'),
+                content: Text('이미 추가된 장소입니다'),
+              ),
+            );
+            return;
+          }
+          final newPlace = PlaceInfo(
+            imageUrl: imageUrl,
+            title: title,
+            description: description,
+            mapX: mapX,
+            mapY: mapY,
+          );
+          onComplete(newPlace);
+        },
+        onCancel: onCancel,
+      );
+    } else if (!isWeb) {
+      return GestureDetector(
+        onTap: onTapAdd,
+        child: Container(
+          width: width * 0.63,
+          height: height * 0.2,
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.grey.shade400),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: const Center(
+            child: Text(
+              '+ 장소 추가',
+              style: TextStyle(fontSize: 16.5),
+            ),
+          ),
+        ),
+      );
+    } else {
+      return const SizedBox.shrink();
+    }
+  }
+}

--- a/lib/pages/add_page/add_page_2/widgets/title_block.dart
+++ b/lib/pages/add_page/add_page_2/widgets/title_block.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+
+class TitleBlock extends StatelessWidget {
+  final String title;
+  const TitleBlock({required this.title, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    double width = MediaQuery.of(context).size.width;
+    final height = MediaQuery.of(context).size.height;
+    if (kIsWeb) width = 430;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text("📍$title", style: const TextStyle(fontSize: 26.7, fontWeight: FontWeight.w900)),
+        const Padding(
+          padding: EdgeInsets.only(left: 37.5),
+          child: Text('근처 코스를 알려드릴게요', style: TextStyle(fontSize: 14.3, color: Color(0xFF757575))),
+        ),
+        SizedBox(height: height * 0.0138),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: width * 0.02),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              const Text('최근 업데이트: ', style: TextStyle(fontSize: 14.3, fontWeight: FontWeight.bold, color: Color(0xFF7F7F7F))),
+              SizedBox(width: width * 0.01),
+              Text(DateTime.now().toLocal().toString().substring(0, 10),
+                  style: TextStyle(fontSize: width * 0.03, color: const Color(0xFF7F7F7F))),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/add_page/add_page_3/add_page_3.dart
+++ b/lib/pages/add_page/add_page_3/add_page_3.dart
@@ -6,14 +6,15 @@ import '../../../components/plan_card.dart';
 import '../../../components/proceed_button.dart';
 import '../../plan_page/plan_page.dart';
 import 'package:provider/provider.dart';
+import 'package:alpha_fe/providers/auth_provider.dart';
 
 
 class AddPage_3 extends StatefulWidget {
-  final String? accessToken;
+
   final int tour_id; // 정상 등록 여부 확인 텍스트
   const AddPage_3({
     required this.tour_id,
-    Key? key, required this.accessToken
+    Key? key,
   }) : super(key: key);
 
   @override
@@ -34,6 +35,7 @@ class _AddPage_3State extends State<AddPage_3> {
   // "이 코스로 할게요!" 버튼 탭할 시 연결되어야 할 페이지, 경로 확정됨
   @override
   Widget build(BuildContext context) {
+    final accessToken = context.read<AuthProvider>().accessToken;
     final height = MediaQuery.of(context).size.height;
     double width = MediaQuery.of(context).size.width;
     if (kIsWeb) {
@@ -79,7 +81,7 @@ class _AddPage_3State extends State<AddPage_3> {
                   size_h: height * 0.38,
                   size_w: width * 0.75,
                   tour_id: widget.tour_id,
-                  accessToken: widget.accessToken,
+                  accessToken: accessToken,
                 ),
               ),
 
@@ -98,7 +100,7 @@ class _AddPage_3State extends State<AddPage_3> {
                   Navigator.push(
                       context,
                       MaterialPageRoute(
-                          builder: (context) => PlanPage(accessToken: widget.accessToken,),
+                          builder: (context) => PlanPage(accessToken: accessToken,),
                       ),
                   );
               },

--- a/lib/pages/home_page/home_page_view_model/home_page_view_model.dart
+++ b/lib/pages/home_page/home_page_view_model/home_page_view_model.dart
@@ -39,7 +39,6 @@ class HomePageViewModel extends ChangeNotifier {
     Navigator.of(context).push(
       CupertinoPageRoute(
         builder: (_) => AddPage_0(
-          accessToken: accessToken,
           sigun: sigunguText(context),
         ),
       ),

--- a/lib/pages/home_page/widgets/upcoming_plan_section.dart
+++ b/lib/pages/home_page/widgets/upcoming_plan_section.dart
@@ -72,7 +72,7 @@ class UpcomingPlanSection extends StatelessWidget {
         Navigator.push(
           context,
           CupertinoPageRoute(
-            builder: (_) => AddPage_0(accessToken: accessToken),
+            builder: (_) => AddPage_0(),
           ),
         );
       },

--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -11,11 +11,13 @@ import 'package:alpha_fe/services/websocket/show_tour_course/show_tour_course_we
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:alpha_fe/pages/home_page/home_page_view_model/home_page_view_model.dart';
+import 'package:alpha_fe/pages/add_page/add_page_0/view_model/add_page_0_view_model.dart';
 
 
 
 List<SingleChildWidget> appProviders = [
   ChangeNotifierProvider(create: (_) => HomePageViewModel()),
+  ChangeNotifierProvider(create: (_) => AddPage0ViewModel()),
   ChangeNotifierProvider(create: (_) => AuthProvider()),
   ChangeNotifierProvider(create: (_) => PlanViewModel()),
   ChangeNotifierProvider(create: (_) => LoadingViewModel()),

--- a/lib/services/http/save_tour_course/save_tour_course_from_add.dart
+++ b/lib/services/http/save_tour_course/save_tour_course_from_add.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 
-import '../../../components/placeinfo_card.dart';
+import 'package:alpha_fe/pages/add_page/add_page_2/models/place_info.dart';
 import '../../../components/save_loading_page.dart';
 import '../../../pages/add_page/add_page_3/add_page_3.dart';
 import '../../dio/authorized_dio.dart';
@@ -9,7 +9,7 @@ import '../../dio/authorized_dio.dart';
 class SaveTourCourseFromAdd {
   Future<void> saveCourse({
     required BuildContext context,
-    required List<MapEntry<String, List<PlaceInfoBlock>>> placeWidgets,
+    required List<MapEntry<String, List<PlaceInfo>>> placeWidgets,
     required int tourId,
   }) async {
     final dio = await getAuthorizedDio(context);

--- a/lib/services/http/save_tour_course/save_tour_course_from_add.dart
+++ b/lib/services/http/save_tour_course/save_tour_course_from_add.dart
@@ -6,6 +6,7 @@ import '../../../components/save_loading_page.dart';
 import '../../../pages/add_page/add_page_3/add_page_3.dart';
 import '../../dio/authorized_dio.dart';
 
+/// TODO: 각 날짜별 코스에 해당되는 장소가 아무것도 없을 때 400 Bad Request 에러 해결해야함
 class SaveTourCourseFromAdd {
   Future<void> saveCourse({
     required BuildContext context,

--- a/lib/services/http/save_tour_course/save_tour_course_from_add.dart
+++ b/lib/services/http/save_tour_course/save_tour_course_from_add.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
-
+import 'package:alpha_fe/components/custom_alert_dialog.dart';
 import 'package:alpha_fe/pages/add_page/add_page_2/models/place_info.dart';
 import '../../../components/save_loading_page.dart';
 import '../../../pages/add_page/add_page_3/add_page_3.dart';
 import '../../dio/authorized_dio.dart';
 
-/// TODO: 각 날짜별 코스에 해당되는 장소가 아무것도 없을 때 400 Bad Request 에러 해결해야함
+
 class SaveTourCourseFromAdd {
   Future<void> saveCourse({
     required BuildContext context,
@@ -15,6 +15,20 @@ class SaveTourCourseFromAdd {
   }) async {
     final dio = await getAuthorizedDio(context);
     const baseUrl = 'http://conever.duckdns.org:8000';
+
+    final hasEmptyDate = placeWidgets.any((entry) => entry.value.isEmpty);
+
+    if (hasEmptyDate) {
+      if (Navigator.canPop(context)) Navigator.pop(context);
+      showDialog(
+        context: context,
+        builder: (_) => const CustomAlertDialog(
+          title: '입력 오류',
+          contentText: '모든 날짜에 최소 하나 이상의 장소를 추가해야 합니다.',
+        ),
+      );
+      return;
+    }
 
     await showDialog(
       context: context,
@@ -62,7 +76,7 @@ class SaveTourCourseFromAdd {
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (_) => AddPage_3(tour_id: tourId, accessToken: '',),
+          builder: (_) => AddPage_3(tour_id: tourId),
         ),
       );
     } catch (e) {


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 작업내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->

**AddPage_2 구조 및 상태관리 개선**
🧩 add_page_2.dart
	•	메인 UI 로직 간소화, 핵심 위젯들을 별도 파일로 분리하여 역할 분리
	•	ViewModel에서 상태 받아 UI만 표시하도록 단순화

🧱 widgets 분리
	•	TitleBlock → 타이틀, 부제목, 최근 업데이트 날짜
	•	DateSelector → 날짜 드롭다운 (ValueNotifier + 변경 콜백)
	•	PlaceInfoListSection → 각 날짜별 장소 리스트 표시 및 편집 모드 시 삭제 버튼 포함
	•	PlaceInputArea → + 장소 추가 버튼 또는 PlaceInputCard 폼 조건 렌더링

🧠 AddPage2ViewModel 개선
	•	resetState()가 무조건 실행되며 isEditMode가 덮어쓰이던 문제 해결
	•	onViewEnter() 내부에 _hasInitialized 플래그로 초기화 시점 제어
	•	UI 전환용 상태인 isEditMode, selectedDate, placeInfos 등의 상태 유지 개선

❗ 저장 시 유효성 검사 강화
	•	각 날짜별 장소가 없는 경우 서버 요청 차단 및 CustomAlertDialog 표시
	•	기존에는 빈 리스트도 서버에 요청 → 400 Bad Request 발생 가능


**AddPage_0 MVVM 구조 재정립**
🧠 AddPage0ViewModel 리팩토링
	•	showDateRangePicker, showDialog 제거 → UI 책임 View로 이동
	•	날짜 유효성 검사 → isValidDateRange(DateTimeRange)
	•	입력값 유효성 판단 → validateInputValuesOnly()

🎨 UI 로직은 View에서 직접 처리
	•	DateSelectSection에서 직접 날짜 선택 처리 및 유효성 검사 수행
	•	ProceedButton 클릭 시 ViewModel 통해 유효성 판단 → 실패 시 CustomAlertDialog 띄움


**저장 로직 개선: SaveTourCourseFromAdd**
저장 유효성 검사 강화
	•	placeWidgets 중 하나라도 장소가 없는 날짜가 있으면 저장 중단
	•	사용자에게 CustomAlertDialog로 오류 메시지 표시

UI 흐름 개선
	•	showDialog → SaveLoadingView 표시 → 조건 실패 시 pop 후 AlertDialog 표시


**기타 정리 사항**
	•	모든 ViewModel은 상태만 책임지고, UI 제어(다이얼로그, 라우팅 등)는 View에서 담당
	•	상태 변경 및 초기화는 resetState, onViewEnter 방식으로 명확히 분리
	•	StatelessWidget 기반 위젯 분리로 코드 가독성 및 테스트 용이성 향상

### 스크린샷 (선택)
<!--스크린샷을 남겨서 PR에 도움을 줄 수 있다면 스크린샷을 넣어주시는 것을 권장드립니다.-->

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말